### PR TITLE
Add expanded structure builders and file-based build workflow

### DIFF
--- a/src/mcp_atomictoolkit/mcp_server.py
+++ b/src/mcp_atomictoolkit/mcp_server.py
@@ -23,14 +23,28 @@ async def build_structure_workflow(
     structure_type: str = "bulk",
     crystal_system: str = "fcc",
     lattice_constant: float = 4.0,
+    pbc: List[bool] = None,
+    cell: Optional[List[List[float]]] = None,
+    cell_size: Optional[List[float]] = None,
+    output_filepath: str = "structure.xyz",
+    output_format: Optional[str] = None,
+    builder_kwargs: Optional[Dict] = None,
 ) -> Dict:
     """Build an atomic structure and return metadata.
 
     Args:
         formula: Chemical formula (e.g. 'Fe', 'TiO2')
-        structure_type: Type of structure ('bulk', 'surface', 'molecule')
+        structure_type: Type of structure
+            ('bulk', 'surface', 'molecule', 'supercell', 'amorphous', 'liquid',
+            'bicrystal', 'polycrystal')
         crystal_system: Crystal system for bulk ('fcc', 'bcc', 'sc', etc.)
         lattice_constant: Lattice constant in Angstroms
+        pbc: Periodic boundary condition flags
+        cell: Explicit 3x3 cell matrix
+        cell_size: Cell lengths (a, b, c) if cell not provided
+        output_filepath: Output file path for the built structure
+        output_format: Output file format (optional)
+        builder_kwargs: Extra builder-specific parameters
 
     Returns:
         Dict containing structure metadata
@@ -40,6 +54,12 @@ async def build_structure_workflow(
         structure_type=structure_type,
         crystal_system=crystal_system,
         lattice_constant=lattice_constant,
+        pbc=pbc or [True, True, True],
+        cell=cell,
+        cell_size=cell_size,
+        output_filepath=output_filepath,
+        output_format=output_format,
+        builder_kwargs=builder_kwargs,
     )
 
 
@@ -144,6 +164,12 @@ async def build_structure(
     structure_type: str = "bulk",
     crystal_system: str = "fcc",
     lattice_constant: float = 4.0,
+    pbc: List[bool] = None,
+    cell: Optional[List[List[float]]] = None,
+    cell_size: Optional[List[float]] = None,
+    output_filepath: str = "structure.xyz",
+    output_format: Optional[str] = None,
+    builder_kwargs: Optional[Dict] = None,
 ) -> Dict:
     """Deprecated: use build_structure_workflow instead."""
     return await build_structure_workflow(
@@ -151,6 +177,12 @@ async def build_structure(
         structure_type=structure_type,
         crystal_system=crystal_system,
         lattice_constant=lattice_constant,
+        pbc=pbc,
+        cell=cell,
+        cell_size=cell_size,
+        output_filepath=output_filepath,
+        output_format=output_format,
+        builder_kwargs=builder_kwargs,
     )
 
 

--- a/src/mcp_atomictoolkit/structure_operations.py
+++ b/src/mcp_atomictoolkit/structure_operations.py
@@ -1,10 +1,84 @@
 """Core structure manipulation operations using ASE."""
 
-from typing import Dict
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+import numpy as np
 from ase import Atoms
 from ase.build import bulk, molecule, surface
-from pymatgen.core import Structure
+from ase.calculators.emt import EMT
+from ase.optimize import BFGS
+from pymatgen.core import Composition, Structure
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+
+
+def _resolve_cell(
+    cell: Optional[Sequence[Sequence[float]]],
+    cell_size: Optional[Sequence[float]],
+    default_size: float,
+) -> Optional[np.ndarray]:
+    if cell is not None:
+        return np.array(cell, dtype=float)
+    if cell_size is not None:
+        if len(cell_size) != 3:
+            raise ValueError("cell_size must be a sequence of length 3")
+        return np.diag(np.array(cell_size, dtype=float))
+    return np.diag([default_size, default_size, default_size])
+
+
+def _assign_species(formula: str, num_atoms: int) -> List[str]:
+    composition = Composition(formula)
+    fractions = composition.fractional_composition.get_el_amt_dict()
+    symbols: List[str] = []
+    remaining = num_atoms
+    for idx, (element, fraction) in enumerate(fractions.items()):
+        if idx == len(fractions) - 1:
+            count = remaining
+        else:
+            count = max(1, int(round(fraction * num_atoms)))
+        symbols.extend([element] * count)
+        remaining -= count
+    if remaining > 0:
+        symbols.extend([list(fractions.keys())[-1]] * remaining)
+    return symbols
+
+
+def _random_packed_structure(
+    formula: str,
+    num_atoms: int,
+    cell_matrix: np.ndarray,
+    pbc: Sequence[bool],
+    relax: bool,
+    relax_steps: int,
+    relax_fmax: float,
+) -> Atoms:
+    symbols = _assign_species(formula, num_atoms)
+    frac_positions = np.random.rand(num_atoms, 3)
+    positions = frac_positions @ cell_matrix
+    atoms = Atoms(symbols=symbols, positions=positions, cell=cell_matrix, pbc=pbc)
+    if relax:
+        atoms.calc = EMT()
+        optimizer = BFGS(atoms, logfile=None)
+        optimizer.run(fmax=relax_fmax, steps=relax_steps)
+    return atoms
+
+
+def _stack_grains(
+    grain_a: Atoms,
+    grain_b: Atoms,
+    axis: int,
+    gap: float,
+    pbc: Sequence[bool],
+) -> Atoms:
+    translation = np.zeros(3)
+    translation[axis] = grain_a.cell.lengths()[axis] + gap
+    grain_b = grain_b.copy()
+    grain_b.translate(translation)
+    combined = grain_a + grain_b
+    cell = grain_a.cell.array.copy()
+    cell[axis] = cell[axis] + grain_b.cell.array[axis] + translation[axis]
+    combined.set_cell(cell)
+    combined.pbc = pbc
+    return combined
 
 
 def create_structure(
@@ -12,15 +86,23 @@ def create_structure(
     structure_type: str = "bulk",
     crystal_system: str = "fcc",
     lattice_constant: float = 4.0,
+    pbc: Sequence[bool] = (True, True, True),
+    cell: Optional[Sequence[Sequence[float]]] = None,
+    cell_size: Optional[Sequence[float]] = None,
     **kwargs,
 ) -> Atoms:
     """Create atomic structure based on type and parameters.
 
     Args:
         formula: Chemical formula
-        structure_type: Type of structure ('bulk', 'surface', 'molecule')
+        structure_type: Type of structure
+            ('bulk', 'surface', 'molecule', 'supercell', 'amorphous', 'liquid',
+            'bicrystal', 'polycrystal')
         crystal_system: Crystal system for bulk
         lattice_constant: Lattice constant in Angstroms
+        pbc: Periodic boundary condition flags
+        cell: Explicit cell matrix (3x3)
+        cell_size: Cell lengths (a, b, c) if cell not provided
         **kwargs: Additional parameters for specific structure types
 
     Returns:
@@ -30,8 +112,12 @@ def create_structure(
         atoms = bulk(
             formula, crystal_system, a=lattice_constant, cubic=kwargs.get("cubic", True)
         )
+        atoms.pbc = pbc
     elif structure_type == "molecule":
         atoms = molecule(formula)
+        atoms.pbc = pbc
+        if cell is not None or cell_size is not None:
+            atoms.set_cell(_resolve_cell(cell, cell_size, lattice_constant * 5))
     elif structure_type == "surface":
         bulk_atoms = bulk(formula, crystal_system, a=lattice_constant)
         atoms = surface(
@@ -40,6 +126,79 @@ def create_structure(
             layers=kwargs.get("layers", 4),
             vacuum=kwargs.get("vacuum", 10.0),
         )
+        atoms.pbc = pbc
+    elif structure_type == "supercell":
+        base_type = kwargs.get("base_structure_type", "bulk")
+        base = create_structure(
+            formula,
+            structure_type=base_type,
+            crystal_system=kwargs.get("base_crystal_system", crystal_system),
+            lattice_constant=kwargs.get("base_lattice_constant", lattice_constant),
+            pbc=pbc,
+            cell=cell,
+            cell_size=cell_size,
+            **kwargs.get("base_kwargs", {}),
+        )
+        size = kwargs.get("size", (2, 2, 2))
+        atoms = base * size
+    elif structure_type in {"amorphous", "liquid"}:
+        num_atoms = int(kwargs.get("num_atoms", 100))
+        cell_matrix = _resolve_cell(
+            cell, cell_size, kwargs.get("box_length", lattice_constant * 3)
+        )
+        atoms = _random_packed_structure(
+            formula=formula,
+            num_atoms=num_atoms,
+            cell_matrix=cell_matrix,
+            pbc=pbc,
+            relax=bool(kwargs.get("relax", False)),
+            relax_steps=int(kwargs.get("relax_steps", 100)),
+            relax_fmax=float(kwargs.get("relax_fmax", 0.1)),
+        )
+    elif structure_type == "bicrystal":
+        grain_size = kwargs.get("grain_size", (4, 4, 4))
+        axis_label = kwargs.get("interface_axis", "z")
+        axis_map = {"x": 0, "y": 1, "z": 2}
+        axis = axis_map.get(axis_label, 2)
+        grain_a = bulk(
+            formula, crystal_system, a=lattice_constant, cubic=kwargs.get("cubic", True)
+        )
+        grain_a = grain_a * grain_size
+        grain_b = grain_a.copy()
+        rotation_angle = float(kwargs.get("rotation_angle", 15.0))
+        rotation_axis = kwargs.get("rotation_axis", (0, 0, 1))
+        grain_b.rotate(rotation_angle, rotation_axis, rotate_cell=True)
+        gap = float(kwargs.get("interface_gap", 0.0))
+        atoms = _stack_grains(grain_a, grain_b, axis=axis, gap=gap, pbc=pbc)
+    elif structure_type == "polycrystal":
+        num_grains = int(kwargs.get("num_grains", 4))
+        grain_size = kwargs.get("grain_size", (3, 3, 3))
+        grid = int(np.ceil(num_grains ** (1 / 3)))
+        base = bulk(
+            formula, crystal_system, a=lattice_constant, cubic=kwargs.get("cubic", True)
+        )
+        grains: List[Atoms] = []
+        for idx in range(num_grains):
+            grain = base * grain_size
+            angle = float(kwargs.get("rotation_angle", 15.0)) * (idx + 1)
+            grain.rotate(angle, (0, 0, 1), rotate_cell=True)
+            shift = np.array(
+                [
+                    (idx % grid) * grain.cell.lengths()[0],
+                    ((idx // grid) % grid) * grain.cell.lengths()[1],
+                    (idx // (grid * grid)) * grain.cell.lengths()[2],
+                ]
+            )
+            grain.translate(shift)
+            grains.append(grain)
+        atoms = grains[0]
+        for grain in grains[1:]:
+            atoms += grain
+        cell_matrix = _resolve_cell(
+            cell, cell_size, lattice_constant * grain_size[0] * grid
+        )
+        atoms.set_cell(cell_matrix)
+        atoms.pbc = pbc
     else:
         raise ValueError(f"Unknown structure type: {structure_type}")
 
@@ -90,19 +249,26 @@ def get_structure_info(atoms: Atoms) -> Dict:
     lattice = atoms.cell.array
     species = atoms.get_chemical_symbols()
     coords = atoms.get_scaled_positions()
-    structure = Structure(lattice, species, coords)
 
-    # Analyze symmetry
-    analyzer = SpacegroupAnalyzer(structure)
+    spacegroup = None
+    crystal_system = None
+    point_group = None
+    if all(atoms.pbc):
+        structure = Structure(lattice, species, coords)
+        analyzer = SpacegroupAnalyzer(structure)
+        spacegroup = analyzer.get_space_group_symbol()
+        crystal_system = analyzer.get_crystal_system()
+        point_group = analyzer.get_point_group_symbol()
 
     return {
         "formula": atoms.get_chemical_formula(),
         "num_atoms": len(atoms),
         "volume": atoms.get_volume(),
+        "cell": atoms.cell.array.tolist(),
         "cell_lengths": atoms.cell.lengths().tolist(),
         "cell_angles": atoms.cell.angles().tolist(),
         "pbc": atoms.pbc.tolist(),
-        "spacegroup": analyzer.get_space_group_symbol(),
-        "crystal_system": analyzer.get_crystal_system(),
-        "point_group": analyzer.get_point_group_symbol(),
+        "spacegroup": spacegroup,
+        "crystal_system": crystal_system,
+        "point_group": point_group,
     }

--- a/src/mcp_atomictoolkit/workflows/core.py
+++ b/src/mcp_atomictoolkit/workflows/core.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Sequence
 
 from ase import Atoms
 
@@ -17,14 +17,38 @@ def build_structure_workflow(
     structure_type: str = "bulk",
     crystal_system: str = "fcc",
     lattice_constant: float = 4.0,
+    pbc: Sequence[bool] = (True, True, True),
+    cell: Optional[List[List[float]]] = None,
+    cell_size: Optional[Sequence[float]] = None,
+    output_filepath: str = "structure.xyz",
+    output_format: Optional[str] = None,
+    builder_kwargs: Optional[Dict] = None,
 ) -> Dict:
-    """Build an atomic structure and return metadata."""
+    """Build an atomic structure, write to disk, and return metadata."""
     structure = create_structure(
-        formula, structure_type, crystal_system, lattice_constant
+        formula,
+        structure_type,
+        crystal_system,
+        lattice_constant,
+        pbc=pbc,
+        cell=cell,
+        cell_size=cell_size,
+        **(builder_kwargs or {}),
     )
+    write_structure(structure, output_filepath, output_format)
+    info = get_structure_info(structure)
+    symmetry_summary = {
+        "spacegroup": info.get("spacegroup"),
+        "crystal_system": info.get("crystal_system"),
+        "point_group": info.get("point_group"),
+    }
     return {
-        "info": get_structure_info(structure),
-        "symbols": structure.get_chemical_symbols(),
+        "filepath": str(Path(output_filepath).absolute()),
+        "format": output_format or Path(output_filepath).suffix[1:],
+        "formula": info.get("formula"),
+        "num_atoms": info.get("num_atoms"),
+        "cell": info.get("cell"),
+        "symmetry": symmetry_summary,
     }
 
 


### PR DESCRIPTION
### Motivation
- Provide richer programmatic builders for common structure types (supercells, amorphous/liquid random packing with optional relaxation, bicrystals/polycrystals, and non-periodic molecules) to support more generation workflows. 
- Ensure builders can produce on-disk files and that MCP RPCs return lightweight metadata (file path + summary) rather than full coordinate arrays to reduce payload size.

### Description
- Added helpers and builders in `src/mcp_atomictoolkit/structure_operations.py`, including `_resolve_cell`, `_assign_species`, `_random_packed_structure`, `_stack_grains`, and extended `create_structure` with new `structure_type` options `supercell`, `amorphous`/`liquid`, `bicrystal`, and `polycrystal`, plus parameters `pbc`, `cell`, and `cell_size`.
- Implemented optional local relaxation for random-packed structures using ASE `EMT` calculator and `BFGS` optimizer, and improved `get_structure_info` to always include `cell` and only compute symmetry when all `pbc` are true.
- Updated workflow `build_structure_workflow` in `src/mcp_atomictoolkit/workflows/core.py` to write the built structure via `io_handlers.write_structure` and to return only `filepath`, `format`, `formula`, `num_atoms`, `cell`, and `symmetry` summary instead of full positions.
- Extended MCP server tool signatures in `src/mcp_atomictoolkit/mcp_server.py` to accept `pbc`, `cell`, `cell_size`, `output_filepath`, `output_format`, and `builder_kwargs`, and to forward those to the updated workflow.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698300e50f5c832e8a3d61a0788741d2)