### PR TITLE
Add ASE constraint support and file-based optimizer with calculator selection

### DIFF
--- a/src/mcp_atomictoolkit/mcp_server.py
+++ b/src/mcp_atomictoolkit/mcp_server.py
@@ -110,33 +110,39 @@ async def write_structure_workflow(
 
 @mcp.tool()
 async def optimize_structure_workflow(
-    positions: List[List[float]],
-    symbols: List[str],
-    cell: List[List[float]],
-    mlip_type: str = "orb",
+    input_filepath: str,
+    input_format: Optional[str] = None,
+    output_filepath: str = "optimized.xyz",
+    output_format: Optional[str] = None,
+    calculator_name: str = "orb",
     max_steps: int = 50,
     fmax: float = 0.1,
+    constraints: Optional[Dict] = None,
 ) -> Dict:
     """Optimize structure using MLIP and return metadata.
 
     Args:
-        positions: Atomic positions
-        symbols: Chemical symbols
-        cell: Unit cell vectors
-        mlip_type: Type of MLIP ('orb' or 'mace')
+        input_filepath: Path to structure file
+        input_format: File format (optional)
+        output_filepath: Output file path
+        output_format: Output file format (optional)
+        calculator_name: Type of MLIP ('orb' or 'mace')
         max_steps: Maximum optimization steps
         fmax: Force convergence criterion
+        constraints: Constraint settings (fixed atoms/cell/bonds)
 
     Returns:
         Dict containing optimized structure metadata
     """
     return optimize_structure_workflow_impl(
-        positions=positions,
-        symbols=symbols,
-        cell=cell,
-        mlip_type=mlip_type,
+        input_filepath=input_filepath,
+        input_format=input_format,
+        output_filepath=output_filepath,
+        output_format=output_format,
+        calculator_name=calculator_name,
         max_steps=max_steps,
         fmax=fmax,
+        constraints=constraints,
     )
 
 
@@ -240,21 +246,25 @@ async def write_structure_file(
 
 @mcp.tool()
 async def optimize_with_mlip(
-    positions: List[List[float]],
-    symbols: List[str],
-    cell: List[List[float]],
-    mlip_type: str = "orb",
+    input_filepath: str,
+    input_format: Optional[str] = None,
+    output_filepath: str = "optimized.xyz",
+    output_format: Optional[str] = None,
+    calculator_name: str = "orb",
     max_steps: int = 50,
     fmax: float = 0.1,
+    constraints: Optional[Dict] = None,
 ) -> Dict:
     """Deprecated: use optimize_structure_workflow instead."""
     return await optimize_structure_workflow(
-        positions=positions,
-        symbols=symbols,
-        cell=cell,
-        mlip_type=mlip_type,
+        input_filepath=input_filepath,
+        input_format=input_format,
+        output_filepath=output_filepath,
+        output_format=output_format,
+        calculator_name=calculator_name,
         max_steps=max_steps,
         fmax=fmax,
+        constraints=constraints,
     )
 
 

--- a/src/mcp_atomictoolkit/workflows/core.py
+++ b/src/mcp_atomictoolkit/workflows/core.py
@@ -85,35 +85,33 @@ def write_structure_workflow(
 
 
 def optimize_structure_workflow(
-    positions: List[List[float]],
-    symbols: List[str],
-    cell: List[List[float]],
-    mlip_type: str = "orb",
+    input_filepath: str,
+    input_format: Optional[str] = None,
+    output_filepath: str = "optimized.xyz",
+    output_format: Optional[str] = None,
+    calculator_name: str = "orb",
     max_steps: int = 50,
     fmax: float = 0.1,
-    output_filepath: Optional[str] = None,
-    output_format: Optional[str] = None,
+    constraints: Optional[Dict] = None,
 ) -> Dict:
-    """Optimize a structure and optionally write results to disk."""
-    structure = Atoms(symbols=symbols, positions=positions, cell=cell, pbc=True)
+    """Optimize a structure read from disk, write results, and return metadata."""
+    structure = read_structure(input_filepath, input_format)
     optimized = optimize_structure(
-        structure, mlip_type=mlip_type, max_steps=max_steps, fmax=fmax
+        structure,
+        calculator_name=calculator_name,
+        max_steps=max_steps,
+        fmax=fmax,
+        constraints=constraints,
     )
 
-    output_path = None
-    if output_filepath:
-        write_structure(optimized, output_filepath, output_format)
-        output_path = str(Path(output_filepath).absolute())
+    write_structure(optimized, output_filepath, output_format)
+    output_path = str(Path(output_filepath).absolute())
 
     return {
-        "info": get_structure_info(optimized),
-        "symbols": optimized.get_chemical_symbols(),
+        "output_filepath": output_path,
         "converged": optimized.info.get("optimization_converged", False),
         "steps": optimized.info.get("optimization_steps", 0),
         "final_fmax": optimized.info.get("optimization_fmax", None),
-        "output_filepath": output_path,
-        "output_format": output_format
-        or (Path(output_filepath).suffix[1:] if output_filepath else None),
     }
 
 


### PR DESCRIPTION
### Motivation
- Enable applying ASE constraints (fixed atoms, fixed bonds, fixed-cell metadata) during structure relaxations and allow selecting the MLIP calculator so other MLIPs can be added later.  
- Move the optimization workflow to operate on files (read input, write optimized output) and return a concise result (output path + convergence metadata) suitable for MCP tool usage.

### Description
- In `src/mcp_atomictoolkit/optimizers.py` added `get_calculator`, implemented `apply_constraints` to apply `FixAtoms`, `FixBondLength`/`FixBondLengths` and store `fixed_cell` in `atoms.info`, and changed `optimize_structure` to accept `calculator_name` and `constraints` and apply constraints before running the optimizer.  
- Updated `optimize_structure_workflow` in `src/mcp_atomictoolkit/workflows/core.py` to read the input structure via `read_structure`, call `optimize_structure` with `calculator_name` and `constraints`, write the optimized structure to `output_filepath`, and return only the `output_filepath` plus convergence metadata (`converged`, `steps`, `final_fmax`).  
- Updated MCP tool signatures in `src/mcp_atomictoolkit/mcp_server.py` to use file-based inputs (`input_filepath`, `input_format`), file outputs (`output_filepath`, `output_format`), `calculator_name`, and `constraints`, and adjusted the deprecated `optimize_with_mlip` wrapper accordingly.  
- Minor typing and import cleanups to support the new APIs and constraint handling.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69830521cd34832ea8038ad4f40e72f3)