### PR TITLE
Add structure, trajectory, and autocorrelation analysis workflows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.13"
 dependencies = [
     "ase>=3.24.0",
     "fastmcp>=0.4.1",
+    "matplotlib>=3.9.0",
     "mcp[cli]>=1.4.1",
     "orb-models>=0.4.2",
     "pymatgen>=2025.3.10",

--- a/src/mcp_atomictoolkit/analysis/__init__.py
+++ b/src/mcp_atomictoolkit/analysis/__init__.py
@@ -1,0 +1,7 @@
+"""Analysis utilities for MCP Atomic Toolkit."""
+
+from mcp_atomictoolkit.analysis.autocorrelation import analyze_vacf
+from mcp_atomictoolkit.analysis.structure import analyze_structure
+from mcp_atomictoolkit.analysis.trajectory import analyze_trajectory
+
+__all__ = ["analyze_structure", "analyze_trajectory", "analyze_vacf"]

--- a/src/mcp_atomictoolkit/analysis/autocorrelation.py
+++ b/src/mcp_atomictoolkit/analysis/autocorrelation.py
@@ -1,0 +1,139 @@
+"""Autocorrelation workflows."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import matplotlib.pyplot as plt
+import numpy as np
+from ase import Atoms
+from ase.io import read
+
+
+def _write_json(data: Dict, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2))
+
+
+def _write_csv(rows: List[List], header: List[str], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+
+def _read_trajectory(filepath: str, format: Optional[str]) -> List[Atoms]:
+    frames = read(filepath, format=format, index=":")
+    if not isinstance(frames, list):
+        return [frames]
+    return frames
+
+
+def _compute_vacf(velocities: np.ndarray, max_lag: int) -> np.ndarray:
+    n_frames = velocities.shape[0]
+    vacf = np.zeros(max_lag + 1)
+    for lag in range(max_lag + 1):
+        v0 = velocities[: n_frames - lag]
+        vt = velocities[lag:]
+        dot = np.sum(v0 * vt, axis=2)
+        vacf[lag] = float(np.mean(dot))
+    return vacf
+
+
+def analyze_vacf(
+    filepath: str,
+    format: Optional[str] = None,
+    output_dir: str = "analysis_outputs/autocorrelation",
+    timestep_fs: float = 1.0,
+    max_lag: Optional[int] = None,
+) -> Dict:
+    """Compute VACF and diffusion coefficients from a trajectory."""
+    frames = _read_trajectory(filepath, format)
+    if not frames:
+        raise ValueError("No frames found in trajectory")
+
+    velocities = []
+    for atoms in frames:
+        vel = atoms.get_velocities()
+        if vel is None:
+            raise ValueError("Trajectory does not contain velocities required for VACF")
+        velocities.append(vel)
+
+    vel_array = np.array(velocities)
+    n_frames = vel_array.shape[0]
+    max_lag = n_frames - 1 if max_lag is None else min(max_lag, n_frames - 1)
+
+    vacf = _compute_vacf(vel_array, max_lag=max_lag)
+    vacf_norm = vacf / vacf[0] if vacf[0] != 0 else vacf
+
+    time_fs = np.arange(max_lag + 1) * timestep_fs
+    dt_fs = timestep_fs
+    diffusion = np.zeros_like(vacf)
+    if len(vacf) > 1:
+        cumulative = np.cumsum(0.5 * (vacf[:-1] + vacf[1:]) * dt_fs)
+        diffusion[1:] = cumulative / 3.0
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    vacf_csv = output_path / "vacf.csv"
+    _write_csv(
+        [[float(t), float(v), float(vn)] for t, v, vn in zip(time_fs, vacf, vacf_norm)],
+        ["time_fs", "vacf", "vacf_normalized"],
+        vacf_csv,
+    )
+
+    vacf_plot = output_path / "vacf.png"
+    plt.figure()
+    plt.plot(time_fs, vacf_norm, color="teal")
+    plt.xlabel("Time (fs)")
+    plt.ylabel("Normalized VACF")
+    plt.title("Velocity autocorrelation function")
+    plt.tight_layout()
+    plt.savefig(vacf_plot)
+    plt.close()
+
+    diffusion_csv = output_path / "diffusion.csv"
+    _write_csv(
+        [[float(t), float(d)] for t, d in zip(time_fs, diffusion)],
+        ["time_fs", "diffusion_A2_per_fs"],
+        diffusion_csv,
+    )
+
+    diffusion_plot = output_path / "diffusion.png"
+    plt.figure()
+    plt.plot(time_fs, diffusion, color="darkorange")
+    plt.xlabel("Time (fs)")
+    plt.ylabel("D (Å$^2$/fs)")
+    plt.title("Diffusion coefficient (Green-Kubo)")
+    plt.tight_layout()
+    plt.savefig(diffusion_plot)
+    plt.close()
+
+    summary = {
+        "input_filepath": str(Path(filepath).absolute()),
+        "format": format or Path(filepath).suffix[1:],
+        "num_frames": n_frames,
+        "timestep_fs": timestep_fs,
+        "vacf_initial": float(vacf[0]),
+        "diffusion_final_A2_per_fs": float(diffusion[-1]) if diffusion.size else 0.0,
+    }
+
+    summary_path = output_path / "vacf_summary.json"
+    _write_json(summary, summary_path)
+
+    return {
+        "summary": summary,
+        "outputs": {
+            "summary_json": str(summary_path.absolute()),
+            "vacf_csv": str(vacf_csv.absolute()),
+            "vacf_plot": str(vacf_plot.absolute()),
+            "diffusion_csv": str(diffusion_csv.absolute()),
+            "diffusion_plot": str(diffusion_plot.absolute()),
+        },
+        "notes": "Computed VACF and diffusion coefficient using Green-Kubo integration.",
+    }

--- a/src/mcp_atomictoolkit/analysis/structure.py
+++ b/src/mcp_atomictoolkit/analysis/structure.py
@@ -1,0 +1,158 @@
+"""Structure analysis workflows."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+from ase import Atoms
+from ase.data import covalent_radii
+from ase.neighborlist import NeighborList, neighbor_list
+
+from mcp_atomictoolkit.io_handlers import read_structure
+from mcp_atomictoolkit.structure_operations import get_structure_info
+
+
+def _write_json(data: Dict, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2))
+
+
+def _write_csv(rows: List[List], header: List[str], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+
+def _compute_rdf(
+    atoms: Atoms, r_max: float, bins: int
+) -> Tuple[np.ndarray, np.ndarray]:
+    distances = neighbor_list("d", atoms, cutoff=r_max)
+    if len(distances) == 0:
+        return np.linspace(0.0, r_max, bins), np.zeros(bins)
+    hist, edges = np.histogram(distances, bins=bins, range=(0.0, r_max))
+    r = 0.5 * (edges[1:] + edges[:-1])
+    dr = edges[1] - edges[0]
+    number_density = len(atoms) / atoms.get_volume() if atoms.get_volume() > 0 else 0
+    shell_volume = 4.0 * np.pi * r**2 * dr
+    normalization = shell_volume * number_density * len(atoms) / 2.0
+    with np.errstate(divide="ignore", invalid="ignore"):
+        g_r = np.where(normalization > 0, hist / normalization, 0.0)
+    return r, g_r
+
+
+def _coordination_numbers(
+    atoms: Atoms, cutoff: Optional[float], factor: float
+) -> Tuple[List[int], Dict[str, float]]:
+    if cutoff is not None:
+        cutoffs = [cutoff] * len(atoms)
+    else:
+        cutoffs = [covalent_radii[atom.number] * factor for atom in atoms]
+    neighborlist = NeighborList(cutoffs, self_interaction=False, bothways=True)
+    neighborlist.update(atoms)
+    coordination = []
+    for idx in range(len(atoms)):
+        indices, _ = neighborlist.get_neighbors(idx)
+        coordination.append(len(indices))
+
+    symbols = atoms.get_chemical_symbols()
+    by_element: Dict[str, List[int]] = {}
+    for symbol, coord in zip(symbols, coordination):
+        by_element.setdefault(symbol, []).append(coord)
+
+    averages = {symbol: float(np.mean(values)) for symbol, values in by_element.items()}
+    return coordination, averages
+
+
+def analyze_structure(
+    filepath: str,
+    format: Optional[str] = None,
+    output_dir: str = "analysis_outputs/structure",
+    rdf_max: float = 10.0,
+    rdf_bins: int = 200,
+    coordination_cutoff: Optional[float] = None,
+    coordination_factor: float = 1.2,
+) -> Dict:
+    """Analyze a structure file and write summary artifacts to disk."""
+    atoms = read_structure(filepath, format)
+    info = get_structure_info(atoms)
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    r, g_r = _compute_rdf(atoms, r_max=rdf_max, bins=rdf_bins)
+    rdf_csv = output_path / "rdf.csv"
+    _write_csv([[float(rv), float(gv)] for rv, gv in zip(r, g_r)], ["r", "g_r"], rdf_csv)
+
+    rdf_plot = output_path / "rdf.png"
+    plt.figure()
+    plt.plot(r, g_r, color="navy")
+    plt.xlabel("r (Å)")
+    plt.ylabel("g(r)")
+    plt.title("Radial Distribution Function")
+    plt.tight_layout()
+    plt.savefig(rdf_plot)
+    plt.close()
+
+    coordination, coordination_by_element = _coordination_numbers(
+        atoms, cutoff=coordination_cutoff, factor=coordination_factor
+    )
+    coordination_csv = output_path / "coordination.csv"
+    symbols = atoms.get_chemical_symbols()
+    _write_csv(
+        [[idx, symbol, coord] for idx, (symbol, coord) in enumerate(zip(symbols, coordination))],
+        ["atom_index", "symbol", "coordination"],
+        coordination_csv,
+    )
+
+    coordination_plot = output_path / "coordination_hist.png"
+    plt.figure()
+    plt.hist(coordination, bins=max(5, int(np.sqrt(len(coordination)))) or 5)
+    plt.xlabel("Coordination number")
+    plt.ylabel("Count")
+    plt.title("Coordination number distribution")
+    plt.tight_layout()
+    plt.savefig(coordination_plot)
+    plt.close()
+
+    summary = {
+        "input_filepath": str(Path(filepath).absolute()),
+        "format": format or Path(filepath).suffix[1:],
+        "num_atoms": info.get("num_atoms"),
+        "symmetry": {
+            "spacegroup": info.get("spacegroup"),
+            "crystal_system": info.get("crystal_system"),
+            "point_group": info.get("point_group"),
+        },
+        "rdf": {
+            "r_max": rdf_max,
+            "bins": rdf_bins,
+        },
+        "coordination": {
+            "cutoff": coordination_cutoff,
+            "factor": coordination_factor,
+            "average": float(np.mean(coordination)) if coordination else 0.0,
+            "by_element": coordination_by_element,
+        },
+    }
+
+    summary_path = output_path / "structure_summary.json"
+    _write_json(summary, summary_path)
+
+    return {
+        "summary": summary,
+        "outputs": {
+            "summary_json": str(summary_path.absolute()),
+            "rdf_csv": str(rdf_csv.absolute()),
+            "rdf_plot": str(rdf_plot.absolute()),
+            "coordination_csv": str(coordination_csv.absolute()),
+            "coordination_plot": str(coordination_plot.absolute()),
+        },
+        "notes": "Computed symmetry metadata, RDF, and coordination statistics.",
+    }

--- a/src/mcp_atomictoolkit/analysis/trajectory.py
+++ b/src/mcp_atomictoolkit/analysis/trajectory.py
@@ -1,0 +1,220 @@
+"""Trajectory analysis workflows."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+from ase import Atoms
+from ase.geometry import find_mic
+from ase.io import read
+from ase.neighborlist import neighbor_list
+
+
+def _write_json(data: Dict, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2))
+
+
+def _write_csv(rows: List[List], header: List[str], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(header)
+        writer.writerows(rows)
+
+
+def _read_trajectory(filepath: str, format: Optional[str]) -> List[Atoms]:
+    frames = read(filepath, format=format, index=":")
+    if not isinstance(frames, list):
+        return [frames]
+    return frames
+
+
+def _compute_rdf(atoms: Atoms, r_max: float, bins: int) -> Tuple[np.ndarray, np.ndarray]:
+    distances = neighbor_list("d", atoms, cutoff=r_max)
+    if len(distances) == 0:
+        return np.linspace(0.0, r_max, bins), np.zeros(bins)
+    hist, edges = np.histogram(distances, bins=bins, range=(0.0, r_max))
+    r = 0.5 * (edges[1:] + edges[:-1])
+    dr = edges[1] - edges[0]
+    number_density = len(atoms) / atoms.get_volume() if atoms.get_volume() > 0 else 0
+    shell_volume = 4.0 * np.pi * r**2 * dr
+    normalization = shell_volume * number_density * len(atoms) / 2.0
+    with np.errstate(divide="ignore", invalid="ignore"):
+        g_r = np.where(normalization > 0, hist / normalization, 0.0)
+    return r, g_r
+
+
+def _extract_energy(atoms: Atoms) -> float:
+    for key in ("energy", "potential_energy", "E"):
+        if key in atoms.info:
+            return float(atoms.info[key])
+    try:
+        return float(atoms.get_potential_energy())
+    except Exception:
+        return float("nan")
+
+
+def analyze_trajectory(
+    filepath: str,
+    format: Optional[str] = None,
+    output_dir: str = "analysis_outputs/trajectory",
+    timestep_fs: float = 1.0,
+    rdf_max: float = 10.0,
+    rdf_bins: int = 200,
+    rdf_stride: int = 1,
+) -> Dict:
+    """Analyze trajectory with MSD, RDF vs time, and thermodynamic stats."""
+    frames = _read_trajectory(filepath, format)
+    if not frames:
+        raise ValueError("No frames found in trajectory")
+
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    positions0 = frames[0].get_positions()
+    msd_rows = []
+    msd_values = []
+    temperatures = []
+    kinetic_energies = []
+    potential_energies = []
+
+    for idx, atoms in enumerate(frames):
+        delta = atoms.get_positions() - positions0
+        if np.any(atoms.pbc):
+            delta, _ = find_mic(delta, atoms.cell, atoms.pbc)
+        msd = float(np.mean(np.sum(delta**2, axis=1)))
+        time_fs = idx * timestep_fs
+        msd_rows.append([time_fs, msd])
+        msd_values.append(msd)
+
+        try:
+            temperatures.append(float(atoms.get_temperature()))
+        except Exception:
+            temperatures.append(float("nan"))
+
+        try:
+            kinetic_energies.append(float(atoms.get_kinetic_energy()))
+        except Exception:
+            kinetic_energies.append(float("nan"))
+
+        potential_energies.append(_extract_energy(atoms))
+
+    msd_csv = output_path / "msd.csv"
+    _write_csv(msd_rows, ["time_fs", "msd_A2"], msd_csv)
+
+    msd_plot = output_path / "msd.png"
+    plt.figure()
+    plt.plot([row[0] for row in msd_rows], msd_values, color="purple")
+    plt.xlabel("Time (fs)")
+    plt.ylabel("MSD (Å$^2$)")
+    plt.title("Mean Squared Displacement")
+    plt.tight_layout()
+    plt.savefig(msd_plot)
+    plt.close()
+
+    rdf_frames = []
+    for idx in range(0, len(frames), max(1, rdf_stride)):
+        atoms = frames[idx]
+        r, g_r = _compute_rdf(atoms, r_max=rdf_max, bins=rdf_bins)
+        rdf_frames.append(
+            {
+                "time_fs": idx * timestep_fs,
+                "r": r.tolist(),
+                "g_r": g_r.tolist(),
+            }
+        )
+
+    rdf_time_csv = output_path / "rdf_time.csv"
+    rdf_rows = []
+    for frame in rdf_frames:
+        for rv, gv in zip(frame["r"], frame["g_r"]):
+            rdf_rows.append([frame["time_fs"], rv, gv])
+    _write_csv(rdf_rows, ["time_fs", "r", "g_r"], rdf_time_csv)
+
+    rdf_plot = output_path / "rdf_time.png"
+    rdf_matrix = np.array([frame["g_r"] for frame in rdf_frames])
+    plt.figure()
+    if rdf_matrix.size > 0:
+        plt.imshow(
+            rdf_matrix,
+            aspect="auto",
+            origin="lower",
+            extent=[0, rdf_max, rdf_frames[0]["time_fs"], rdf_frames[-1]["time_fs"]],
+            cmap="viridis",
+        )
+        plt.colorbar(label="g(r)")
+        plt.xlabel("r (Å)")
+        plt.ylabel("Time (fs)")
+        plt.title("RDF vs time")
+    plt.tight_layout()
+    plt.savefig(rdf_plot)
+    plt.close()
+
+    thermo_rows = []
+    for idx, (temp, kin, pot) in enumerate(
+        zip(temperatures, kinetic_energies, potential_energies)
+    ):
+        thermo_rows.append([idx * timestep_fs, temp, kin, pot])
+
+    thermo_csv = output_path / "thermo.csv"
+    _write_csv(
+        thermo_rows,
+        ["time_fs", "temperature_K", "kinetic_energy_eV", "potential_energy_eV"],
+        thermo_csv,
+    )
+
+    thermo_plot = output_path / "thermo.png"
+    plt.figure()
+    plt.plot([row[0] for row in thermo_rows], temperatures, label="Temperature (K)")
+    plt.plot([row[0] for row in thermo_rows], potential_energies, label="Potential (eV)")
+    plt.xlabel("Time (fs)")
+    plt.legend()
+    plt.title("Thermodynamic time series")
+    plt.tight_layout()
+    plt.savefig(thermo_plot)
+    plt.close()
+
+    summary = {
+        "input_filepath": str(Path(filepath).absolute()),
+        "format": format or Path(filepath).suffix[1:],
+        "num_frames": len(frames),
+        "timestep_fs": timestep_fs,
+        "msd_final": msd_values[-1] if msd_values else 0.0,
+        "temperature_stats": {
+            "mean": float(np.nanmean(temperatures)),
+            "min": float(np.nanmin(temperatures)),
+            "max": float(np.nanmax(temperatures)),
+        },
+        "potential_energy_stats": {
+            "mean": float(np.nanmean(potential_energies)),
+            "min": float(np.nanmin(potential_energies)),
+            "max": float(np.nanmax(potential_energies)),
+        },
+    }
+
+    summary_path = output_path / "trajectory_summary.json"
+    _write_json(summary, summary_path)
+
+    rdf_json = output_path / "rdf_time.json"
+    _write_json({"frames": rdf_frames}, rdf_json)
+
+    return {
+        "summary": summary,
+        "outputs": {
+            "summary_json": str(summary_path.absolute()),
+            "msd_csv": str(msd_csv.absolute()),
+            "msd_plot": str(msd_plot.absolute()),
+            "rdf_time_csv": str(rdf_time_csv.absolute()),
+            "rdf_time_json": str(rdf_json.absolute()),
+            "rdf_time_plot": str(rdf_plot.absolute()),
+            "thermo_csv": str(thermo_csv.absolute()),
+            "thermo_plot": str(thermo_plot.absolute()),
+        },
+        "notes": "Computed MSD, RDF vs time, and temperature/energy statistics.",
+    }

--- a/src/mcp_atomictoolkit/mcp_server.py
+++ b/src/mcp_atomictoolkit/mcp_server.py
@@ -65,7 +65,13 @@ async def build_structure_workflow(
 
 @mcp.tool()
 async def analyze_structure_workflow(
-    filepath: str, format: Optional[str] = None
+    filepath: str,
+    format: Optional[str] = None,
+    output_dir: str = "analysis_outputs/structure",
+    rdf_max: float = 10.0,
+    rdf_bins: int = 200,
+    coordination_cutoff: Optional[float] = None,
+    coordination_factor: float = 1.2,
 ) -> Dict:
     """Analyze structure file and return metadata.
 
@@ -76,7 +82,15 @@ async def analyze_structure_workflow(
     Returns:
         Dict containing structure metadata
     """
-    return analyze_structure_workflow_impl(filepath=filepath, format=format)
+    return analyze_structure_workflow_impl(
+        filepath=filepath,
+        format=format,
+        output_dir=output_dir,
+        rdf_max=rdf_max,
+        rdf_bins=rdf_bins,
+        coordination_cutoff=coordination_cutoff,
+        coordination_factor=coordination_factor,
+    )
 
 
 @mcp.tool()
@@ -181,15 +195,43 @@ async def run_md_workflow(
 
 
 @mcp.tool()
-async def analyze_trajectory_workflow(*args, **kwargs) -> Dict:
-    """Analyze trajectory workflow (not yet implemented)."""
-    return analyze_trajectory_workflow_impl(*args, **kwargs)
+async def analyze_trajectory_workflow(
+    filepath: str,
+    format: Optional[str] = None,
+    output_dir: str = "analysis_outputs/trajectory",
+    timestep_fs: float = 1.0,
+    rdf_max: float = 10.0,
+    rdf_bins: int = 200,
+    rdf_stride: int = 1,
+) -> Dict:
+    """Analyze a trajectory and return analysis artifacts."""
+    return analyze_trajectory_workflow_impl(
+        filepath=filepath,
+        format=format,
+        output_dir=output_dir,
+        timestep_fs=timestep_fs,
+        rdf_max=rdf_max,
+        rdf_bins=rdf_bins,
+        rdf_stride=rdf_stride,
+    )
 
 
 @mcp.tool()
-async def autocorrelation_workflow(*args, **kwargs) -> Dict:
-    """Autocorrelation workflow (not yet implemented)."""
-    return autocorrelation_workflow_impl(*args, **kwargs)
+async def autocorrelation_workflow(
+    filepath: str,
+    format: Optional[str] = None,
+    output_dir: str = "analysis_outputs/autocorrelation",
+    timestep_fs: float = 1.0,
+    max_lag: Optional[int] = None,
+) -> Dict:
+    """Autocorrelation workflow for VACF and diffusion."""
+    return autocorrelation_workflow_impl(
+        filepath=filepath,
+        format=format,
+        output_dir=output_dir,
+        timestep_fs=timestep_fs,
+        max_lag=max_lag,
+    )
 
 
 @mcp.tool()

--- a/src/mcp_atomictoolkit/workflows/core.py
+++ b/src/mcp_atomictoolkit/workflows/core.py
@@ -7,6 +7,9 @@ from typing import Dict, List, Optional, Sequence
 
 from ase import Atoms
 
+from mcp_atomictoolkit.analysis.autocorrelation import analyze_vacf
+from mcp_atomictoolkit.analysis.structure import analyze_structure
+from mcp_atomictoolkit.analysis.trajectory import analyze_trajectory
 from mcp_atomictoolkit.io_handlers import read_structure, write_structure
 from mcp_atomictoolkit.md_runner import run_md
 from mcp_atomictoolkit.optimizers import optimize_structure
@@ -56,14 +59,29 @@ def build_structure_workflow(
 def analyze_structure_workflow(
     filepath: str,
     format: Optional[str] = None,
+    output_dir: str = "analysis_outputs/structure",
+    rdf_max: float = 10.0,
+    rdf_bins: int = 200,
+    coordination_cutoff: Optional[float] = None,
+    coordination_factor: float = 1.2,
 ) -> Dict:
-    """Analyze a structure file and return metadata."""
+    """Analyze a structure file and return metadata and analysis artifacts."""
+    analysis = analyze_structure(
+        filepath=filepath,
+        format=format,
+        output_dir=output_dir,
+        rdf_max=rdf_max,
+        rdf_bins=rdf_bins,
+        coordination_cutoff=coordination_cutoff,
+        coordination_factor=coordination_factor,
+    )
     structure = read_structure(filepath, format)
     return {
         "filepath": str(Path(filepath).absolute()),
         "format": format or Path(filepath).suffix[1:],
         "info": get_structure_info(structure),
         "symbols": structure.get_chemical_symbols(),
+        "analysis": analysis,
     }
 
 
@@ -148,11 +166,39 @@ def run_md_workflow(
     )
 
 
-def analyze_trajectory_workflow(*_args, **_kwargs) -> Dict:
-    """Placeholder for trajectory analysis workflow."""
-    raise NotImplementedError("Trajectory analysis workflow is not implemented yet.")
+def analyze_trajectory_workflow(
+    filepath: str,
+    format: Optional[str] = None,
+    output_dir: str = "analysis_outputs/trajectory",
+    timestep_fs: float = 1.0,
+    rdf_max: float = 10.0,
+    rdf_bins: int = 200,
+    rdf_stride: int = 1,
+) -> Dict:
+    """Analyze a trajectory and return analysis artifacts."""
+    return analyze_trajectory(
+        filepath=filepath,
+        format=format,
+        output_dir=output_dir,
+        timestep_fs=timestep_fs,
+        rdf_max=rdf_max,
+        rdf_bins=rdf_bins,
+        rdf_stride=rdf_stride,
+    )
 
 
-def autocorrelation_workflow(*_args, **_kwargs) -> Dict:
-    """Placeholder for autocorrelation workflow."""
-    raise NotImplementedError("Autocorrelation workflow is not implemented yet.")
+def autocorrelation_workflow(
+    filepath: str,
+    format: Optional[str] = None,
+    output_dir: str = "analysis_outputs/autocorrelation",
+    timestep_fs: float = 1.0,
+    max_lag: Optional[int] = None,
+) -> Dict:
+    """Compute VACF/autocorrelation analysis and diffusion coefficients."""
+    return analyze_vacf(
+        filepath=filepath,
+        format=format,
+        output_dir=output_dir,
+        timestep_fs=timestep_fs,
+        max_lag=max_lag,
+    )


### PR DESCRIPTION
### Motivation
- Provide on-disk analysis tooling for structures and trajectories to produce symmetry/RDF/coordination, MSD/RDF-vs-time/thermo statistics, and VACF/diffusion outputs for downstream inspection and MCP tooling.
- Surface these analyses through the existing workflow and MCP server APIs so analysis artifacts can be returned to callers.

### Description
- Added new analysis modules `src/mcp_atomictoolkit/analysis/structure.py`, `src/mcp_atomictoolkit/analysis/trajectory.py`, and `src/mcp_atomictoolkit/analysis/autocorrelation.py` that compute symmetry metadata, RDF, coordination numbers, MSD, RDF vs time, temperature/energy stats, VACF, and Green–Kubo diffusion; each writes JSON/CSV/plot files and returns output paths with summaries.
- Exported the analysis functions via `src/mcp_atomictoolkit/analysis/__init__.py` and wired the workflows in `src/mcp_atomictoolkit/workflows/core.py` to call `analyze_structure`, `analyze_trajectory`, and `analyze_vacf` and return analysis artifacts.
- Exposed the analysis parameters through the MCP API by updating `src/mcp_atomictoolkit/mcp_server.py` tool signatures for `analyze_structure_workflow`, `analyze_trajectory_workflow`, and `autocorrelation_workflow`.
- Added `matplotlib` to `pyproject.toml` dependencies to enable plot generation.

### Testing
- No automated tests were executed for these changes (no test suite run as part of this PR).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983074034c0832e9947fefe253870d7)