### PR TITLE
Add Render deployment support: entrypoint, render.yaml, and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,22 +22,38 @@ from nequix.calculator import NequixCalculator
 atoms = ...
 atoms.calc = NequixCalculator("nequix-mp-1", backend="jax")
 ```
-## Deploy to Hugging Face (Docker Space)
-Use a Docker Space to host the MCP server with SSE transport.
+## Deploy to Render (Web Service)
+Render can run the MCP server directly from this repository.
 
-1. Create a new Hugging Face Space and select **Docker** as the SDK.
-2. Push this repository to the Space.
-3. Ensure the Space is running; it will start the MCP server on port `7860`.
-
-### Files used by the Space
-- `Dockerfile`: installs the package and runs the SSE server.
+### Files used by Render
 - `requirements.txt`: installs this repo and its dependencies.
-- `hf_server.py`: starts the MCP server with the correct transport.
+- `main.py`: starts the MCP server with the correct host/port and SSE transport.
+- `render.yaml`: provides a reproducible Render service definition.
+
+### render.yaml
+The repository includes the `render.yaml` below:
+```yaml
+services:
+  - type: web
+    name: mcp-atomictoolkit
+    env: python
+    plan: free
+    buildCommand: pip install -r requirements.txt
+    startCommand: python main.py
+    envVars:
+      - key: PYTHON_VERSION
+        value: "3.13"
+```
+
+### One-time setup
+1. In Render, create a **New Web Service** and connect this GitHub repo.
+2. Render will auto-detect `render.yaml`. If prompted, confirm the build and start commands.
+3. Deploy. Render sets `$PORT` automatically and `main.py` binds to `0.0.0.0`.
 
 ### Server URL
-Once the Space is running, the SSE endpoint will be:
+Once running, the SSE endpoint will be:
 ```
-https://<hf-username>-<space-name>.hf.space/sse
+https://<render-service-name>.onrender.com/sse
 ```
 
 ### Listing on Smithery

--- a/main.py
+++ b/main.py
@@ -1,0 +1,9 @@
+import os
+
+from mcp_atomictoolkit.mcp_server import mcp
+
+
+if __name__ == "__main__":
+    host = os.environ.get("HOST", "0.0.0.0")
+    port = int(os.environ.get("PORT", "10000"))
+    mcp.run(transport="sse", host=host, port=port)

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,10 @@
+services:
+  - type: web
+    name: mcp-atomictoolkit
+    env: python
+    plan: free
+    buildCommand: pip install -r requirements.txt
+    startCommand: python main.py
+    envVars:
+      - key: PYTHON_VERSION
+        value: "3.13"


### PR DESCRIPTION
### Motivation
- Provide a reproducible Render deployment path so the MCP server can be run directly from the repo with minimal setup.
- Ensure the server binds to `0.0.0.0` and respects `PORT` so Render can route traffic correctly.
- Replace the outdated Hugging Face Space instructions with Render-specific documentation and configuration.

### Description
- Add `main.py` which reads `HOST` (default `0.0.0.0`) and `PORT` (default `10000`) from the environment and runs `mcp.run(transport="sse", host=host, port=port)` to start the SSE server. 
- Add `render.yaml` that defines a reproducible Render `web` service with `buildCommand: pip install -r requirements.txt`, `startCommand: python main.py`, and an explicit `PYTHON_VERSION: "3.13"` env var. 
- Update `README.md` to remove the Hugging Face Docker Space section, add the Render usage docs and include the `render.yaml` snippet and the SSE endpoint example.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983b6fb5208832e9a64ebfe1efbc7c5)