### PR TITLE
fix: expose MCP over HTTP via Starlette + Uvicorn (add /healthz)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,15 @@ services:
 ### One-time setup
 1. In Render, create a **New Web Service** and connect this GitHub repo.
 2. Render will auto-detect `render.yaml`. If prompted, confirm the build and start commands.
-3. Deploy. Render sets `$PORT` automatically and `main.py` binds to `0.0.0.0`.
+3. Deploy. Render sets `$PORT` automatically and `main.py` starts Uvicorn on `0.0.0.0:$PORT`.
+
+### If Render reports "No open ports detected"
+Ensure the service is using the Render blueprint values so Uvicorn starts the HTTP server.
+Set these in the Render UI if they were overridden:
+
+- **Build Command**: `pip install -r requirements.txt`
+- **Start Command**: `python main.py`
+- **Health Check Path**: `/healthz`
 
 ### Server URL
 Once running, the SSE endpoint will be:

--- a/hf_server.py
+++ b/hf_server.py
@@ -1,9 +1,11 @@
 import os
 
-from mcp_atomictoolkit.mcp_server import mcp
+import uvicorn
+
+from mcp_atomictoolkit.http_app import app
 
 
 if __name__ == "__main__":
     host = os.environ.get("HOST", "0.0.0.0")
     port = int(os.environ.get("PORT", "7860"))
-    mcp.run(transport="sse", host=host, port=port)
+    uvicorn.run(app, host=host, port=port, log_level="info")

--- a/main.py
+++ b/main.py
@@ -1,9 +1,11 @@
 import os
 
-from mcp_atomictoolkit.mcp_server import mcp
+import uvicorn
+
+from mcp_atomictoolkit.http_app import app
 
 
 if __name__ == "__main__":
     host = os.environ.get("HOST", "0.0.0.0")
     port = int(os.environ.get("PORT", "10000"))
-    mcp.run(transport="sse", host=host, port=port)
+    uvicorn.run(app, host=host, port=port, log_level="info")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,4 +13,6 @@ dependencies = [
     "orb-models>=0.4.2",
     "pymatgen>=2025.3.10",
     "pynanoflann>=0.10.0",
+    "starlette>=0.37.0",
+    "uvicorn>=0.30.0",
 ]

--- a/src/mcp_atomictoolkit/http_app.py
+++ b/src/mcp_atomictoolkit/http_app.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+from fastmcp.server import SseServerTransport
+
+from mcp_atomictoolkit.mcp_server import mcp
+
+
+sse = SseServerTransport("/messages")
+
+
+async def handle_sse(request):
+    async with sse.connect_sse(request.scope, request.receive, request._send) as streams:
+        await mcp._mcp_server.run(
+            streams[0],
+            streams[1],
+            mcp._mcp_server.create_initialization_options(),
+        )
+
+
+async def handle_messages(request):
+    await sse.handle_post_message(request.scope, request.receive, request._send)
+
+
+async def handle_healthz(request):
+    return JSONResponse({"status": "ok"})
+
+
+app = Starlette(
+    debug=mcp.settings.debug,
+    routes=[
+        Route("/sse", endpoint=handle_sse),
+        Route("/messages", endpoint=handle_messages, methods=["POST"]),
+        Route("/healthz", endpoint=handle_healthz),
+    ],
+)


### PR DESCRIPTION
### Motivation
- Render requires a standard HTTP/TCP listener on `$PORT`, and calling `mcp.run()` directly did not guarantee an externally visible listener, causing deploys to report "No open ports detected".
- Provide a minimal, reliable wrapper so MCP is served over HTTP/SSE and Render can detect the port.
- Simplify the README by removing noisy troubleshooting and making the required Render settings explicit.

### Description
- Added a Starlette wrapper at `src/mcp_atomictoolkit/http_app.py` that exposes MCP SSE endpoints and a `/healthz` JSON health check using `fastmcp.server.SseServerTransport`.
- Updated `main.py` and `hf_server.py` to start the Starlette app via `uvicorn`, which binds `0.0.0.0:$PORT` so Render can detect the open port.
- Declared `starlette` and `uvicorn` in `pyproject.toml` and removed stale `src/mcp_atomictoolkit.egg-info` metadata files.
- Cleaned up `README.md` to remove unnecessary troubleshooting text and document the `Build Command`, `Start Command`, and `Health Check Path` for Render.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983c91aa324832eb99b7779c72ba296)