### PR TITLE
Use Uvicorn with $PORT and health check; defer MLIP imports in optimizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ services:
 1. In Render, create a **New Web Service** and connect this GitHub repo.
 2. Render will auto-detect `render.yaml`. If prompted, confirm the build and start commands.
 3. Deploy. Render sets `$PORT` automatically and Uvicorn binds to `0.0.0.0:$PORT`.
+   (`python main.py` is also valid because it reads `$PORT`, but the blueprint defaults to the Uvicorn
+   module invocation.)
 
 ### If Render reports "No open ports detected"
 Ensure the service is using the Render blueprint values so Uvicorn starts the HTTP server.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Render can run the MCP server directly from this repository.
 
 ### Files used by Render
 - `requirements.txt`: installs this repo and its dependencies.
-- `main.py`: starts the MCP server with the correct host/port and SSE transport.
+- `main.py`: optional entrypoint that starts the MCP server with the correct host/port and SSE transport.
 - `render.yaml`: provides a reproducible Render service definition.
 
 ### render.yaml
@@ -39,7 +39,8 @@ services:
     env: python
     plan: free
     buildCommand: pip install -r requirements.txt
-    startCommand: python main.py
+    startCommand: uvicorn mcp_atomictoolkit.http_app:app --host 0.0.0.0 --port $PORT
+    healthCheckPath: /healthz
     envVars:
       - key: PYTHON_VERSION
         value: "3.13"
@@ -48,14 +49,14 @@ services:
 ### One-time setup
 1. In Render, create a **New Web Service** and connect this GitHub repo.
 2. Render will auto-detect `render.yaml`. If prompted, confirm the build and start commands.
-3. Deploy. Render sets `$PORT` automatically and `main.py` starts Uvicorn on `0.0.0.0:$PORT`.
+3. Deploy. Render sets `$PORT` automatically and Uvicorn binds to `0.0.0.0:$PORT`.
 
 ### If Render reports "No open ports detected"
 Ensure the service is using the Render blueprint values so Uvicorn starts the HTTP server.
 Set these in the Render UI if they were overridden:
 
 - **Build Command**: `pip install -r requirements.txt`
-- **Start Command**: `python main.py`
+- **Start Command**: `uvicorn mcp_atomictoolkit.http_app:app --host 0.0.0.0 --port $PORT`
 - **Health Check Path**: `/healthz`
 
 ### Server URL

--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,8 @@ services:
     env: python
     plan: free
     buildCommand: pip install -r requirements.txt
-    startCommand: python main.py
+    startCommand: uvicorn mcp_atomictoolkit.http_app:app --host 0.0.0.0 --port $PORT
+    healthCheckPath: /healthz
     envVars:
       - key: PYTHON_VERSION
         value: "3.13"

--- a/src/mcp_atomictoolkit/optimizers.py
+++ b/src/mcp_atomictoolkit/optimizers.py
@@ -1,20 +1,24 @@
 """Structure optimization using MLIPs (Orb and Nequix)."""
 
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 
 import numpy as np
 from ase import Atoms
 from ase.constraints import FixAtoms, FixBondLength, FixBondLengths
 from ase.optimize import BFGS
-from nequix.calculator import NequixCalculator
-from orb_models.forcefield import pretrained
-from orb_models.forcefield.calculator import ORBCalculator
+
+if TYPE_CHECKING:
+    from nequix.calculator import NequixCalculator
+    from orb_models.forcefield.calculator import ORBCalculator
 
 NEQUIX_DEFAULT_MODEL = "nequix-mp-1"
 
 
-def get_orb_calculator() -> ORBCalculator:
+def get_orb_calculator() -> "ORBCalculator":
     """Initialize Orb calculator."""
+    from orb_models.forcefield import pretrained
+    from orb_models.forcefield.calculator import ORBCalculator
+
     orbff = pretrained.orb_v2(device="cpu")
     calculator = ORBCalculator(orbff, device="cpu")
     return calculator
@@ -23,15 +27,17 @@ def get_orb_calculator() -> ORBCalculator:
 def get_nequix_calculator(
     model_name: str = NEQUIX_DEFAULT_MODEL,
     backend: str = "jax",
-) -> NequixCalculator:
+) -> "NequixCalculator":
     """Initialize Nequix calculator on CPU."""
+    from nequix.calculator import NequixCalculator
+
     return NequixCalculator(
         model_name,
         backend=backend,
     )
 
 
-def get_calculator(calculator_name: str) -> ORBCalculator | NequixCalculator:
+def get_calculator(calculator_name: str) -> "ORBCalculator | NequixCalculator":
     """Return an ASE calculator for the requested MLIP."""
     calculator_key = calculator_name.lower()
     if calculator_key == "orb":


### PR DESCRIPTION
### Motivation
- Fix Render "no open ports detected" timeout by ensuring the service binds to the port Render provides (`$PORT`) and expose a health check endpoint. 
- Reduce server import-time overhead and avoid initializing heavy MLIP libraries until a calculator is requested to speed startup and reduce failures in constrained deploy environments.

### Description
- Update `render.yaml` to use `startCommand: uvicorn mcp_atomictoolkit.http_app:app --host 0.0.0.0 --port $PORT` and add `healthCheckPath: /healthz`.
- Update `README.md` to reflect the new start command and clarify that `main.py` is an optional entrypoint rather than the required startup invocation.
- Modify `src/mcp_atomictoolkit/optimizers.py` to defer runtime imports of `nequix.calculator` and `orb_models.forcefield` into `get_nequix_calculator` and `get_orb_calculator`, add `TYPE_CHECKING`-guarded imports to preserve type hints, and switch return annotations to forward-referenced string types.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983d90aa004832e8d49adf36f8fd88e)