### PR TITLE
Fix FastMCP initialization compatibility

### DIFF
--- a/src/mcp_atomictoolkit/mcp_server.py
+++ b/src/mcp_atomictoolkit/mcp_server.py
@@ -13,7 +13,6 @@ from mcp_atomictoolkit.workflows.core import (
 
 mcp = FastMCP(
     "atomictoolkit",
-    description="ASE and more tools",
 )
 
 


### PR DESCRIPTION
### Motivation
- Startup failed with `TypeError: FastMCP.__init__() got an unexpected keyword argument 'description'`, so the unsupported `description` kwarg was removed to restore compatibility with FastMCP versions that do not accept it.

### Description
- Removed the `description="ASE and more tools"` argument from the `FastMCP("atomictoolkit", ...)` initialization in `src/mcp_atomictoolkit/mcp_server.py`.

### Testing
- Ran `python main.py` and verified the run proceeds past the previous `FastMCP` initialization error, but the process then failed with `ModuleNotFoundError: No module named 'uvicorn'` due to missing runtime dependencies in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698426069ae0832e852323374b4473f4)