### PR TITLE
fix: add MCP server-card endpoint to resolve Render scan 404s

### DIFF
--- a/src/mcp_atomictoolkit/http_app.py
+++ b/src/mcp_atomictoolkit/http_app.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from mcp_atomictoolkit.mcp_server import mcp
@@ -8,8 +9,49 @@ from mcp_atomictoolkit.mcp_server import mcp
 app = mcp.http_app(path="/sse", transport="sse")
 
 
-async def handle_healthz(request):
+def _public_base_url(request: Request) -> str:
+    """Compute public base URL, honoring reverse-proxy headers."""
+    forwarded_proto = request.headers.get("x-forwarded-proto")
+    forwarded_host = request.headers.get("x-forwarded-host")
+    if forwarded_proto and forwarded_host:
+        return f"{forwarded_proto}://{forwarded_host}"
+    return str(request.base_url).rstrip("/")
+
+
+async def handle_root(request: Request) -> JSONResponse:
+    base_url = _public_base_url(request)
+    return JSONResponse(
+        {
+            "name": "atomictoolkit",
+            "status": "ok",
+            "mcp_sse_url": f"{base_url}/sse",
+            "server_card_url": f"{base_url}/.well-known/mcp/server-card.json",
+        }
+    )
+
+
+async def handle_healthz(request: Request) -> JSONResponse:
     return JSONResponse({"status": "ok"})
 
 
+async def handle_server_card(request: Request) -> JSONResponse:
+    """Serve MCP server-card for directory scanners (e.g., Smithery)."""
+    base_url = _public_base_url(request)
+    return JSONResponse(
+        {
+            "name": "atomictoolkit",
+            "description": "Atomistic simulation MCP server powered by ASE and MLIPs.",
+            "version": "0.1.0",
+            "transports": [
+                {
+                    "type": "sse",
+                    "url": f"{base_url}/sse",
+                }
+            ],
+        }
+    )
+
+
+app.add_route("/", handle_root)
 app.add_route("/healthz", handle_healthz)
+app.add_route("/.well-known/mcp/server-card.json", handle_server_card)


### PR DESCRIPTION
### Motivation
- Directory scanners reported `Initialization failed with status 404` because they could not discover the MCP endpoint via a server card, causing automated scans to fail. 
- The server should advertise a public SSE URL and behave correctly behind Render's reverse proxy so scanners see reachable URLs. 
- Documentation should explain common "Authorization Required" scan failures and how to verify the server-card and endpoints. 

### Description
- Add a `/.well-known/mcp/server-card.json` route that returns a minimal MCP server card advertising the SSE transport and public SSE URL. 
- Add a small root JSON status route at `/` that advertises `mcp_sse_url` and `server_card_url`. 
- Add `_public_base_url(request: Request)` which honors `x-forwarded-proto` and `x-forwarded-host` so advertised URLs are correct behind reverse proxies, and wire the new routes into the app in `src/mcp_atomictoolkit/http_app.py`. 
- Update `README.md` troubleshooting to include checks for `/.well-known/mcp/server-card.json`, a `curl` checklist, and guidance about `Initialization failed with status 404` and "Authorization Required" scan errors. 

### Testing
- Ran `python -m compileall src/mcp_atomictoolkit/http_app.py` and it completed successfully. 
- Inspected the resulting changes with `git diff` and `nl` prints of `README.md` and `src/mcp_atomictoolkit/http_app.py`, which matched the intended edits. 
- The changes were committed; no runtime tests were executed in this PR, and all automated inspection steps above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698437dbdf1c832eb0efd82e15539172)