### PR TITLE
Harden Smithery MCP initialization compatibility across /, /sse, and /sse/

### DIFF
--- a/src/mcp_atomictoolkit/http_app.py
+++ b/src/mcp_atomictoolkit/http_app.py
@@ -1,12 +1,29 @@
 from __future__ import annotations
 
+from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, RedirectResponse
+from starlette.routing import Mount, Route
 
 from mcp_atomictoolkit.mcp_server import mcp
 
 
-app = mcp.http_app(path="/sse", transport="sse")
+class _PathRewriteApp:
+    """ASGI adapter that rewrites incoming path before delegating."""
+
+    def __init__(self, app, target_path: str = "/") -> None:
+        self.app = app
+        self.target_path = target_path
+
+    async def __call__(self, scope, receive, send) -> None:
+        rewritten_scope = dict(scope)
+        rewritten_scope["path"] = self.target_path
+        rewritten_scope["raw_path"] = self.target_path.encode("utf-8")
+        await self.app(rewritten_scope, receive, send)
+
+
+# Primary MCP endpoint expected by Smithery and most registries.
+_mcp_root_app = mcp.http_app(path="/", transport="streamable-http")
 
 
 def _public_base_url(request: Request) -> str:
@@ -16,18 +33,6 @@ def _public_base_url(request: Request) -> str:
     if forwarded_proto and forwarded_host:
         return f"{forwarded_proto}://{forwarded_host}"
     return str(request.base_url).rstrip("/")
-
-
-async def handle_root(request: Request) -> JSONResponse:
-    base_url = _public_base_url(request)
-    return JSONResponse(
-        {
-            "name": "atomictoolkit",
-            "status": "ok",
-            "mcp_sse_url": f"{base_url}/sse",
-            "server_card_url": f"{base_url}/.well-known/mcp/server-card.json",
-        }
-    )
 
 
 async def handle_healthz(request: Request) -> JSONResponse:
@@ -44,14 +49,30 @@ async def handle_server_card(request: Request) -> JSONResponse:
             "version": "0.1.0",
             "transports": [
                 {
-                    "type": "sse",
-                    "url": f"{base_url}/sse",
-                }
+                    "type": "streamable-http",
+                    "url": f"{base_url}/",
+                },
+                {
+                    "type": "streamable-http",
+                    "url": f"{base_url}/sse/",
+                },
             ],
         }
     )
 
 
-app.add_route("/", handle_root)
-app.add_route("/healthz", handle_healthz)
-app.add_route("/.well-known/mcp/server-card.json", handle_server_card)
+async def handle_sse_no_slash(request: Request):
+    """Normalize /sse -> /sse/ so the mounted compatibility app handles it."""
+    return RedirectResponse(url="/sse/", status_code=307)
+
+
+app = Starlette(
+    routes=[
+        Route("/healthz", handle_healthz),
+        Route("/.well-known/mcp/server-card.json", handle_server_card),
+        Route("/sse", handle_sse_no_slash, methods=["GET", "HEAD", "POST", "DELETE"]),
+        Mount("/sse", app=_PathRewriteApp(_mcp_root_app, target_path="/")),
+        Mount("/", app=_mcp_root_app),
+    ],
+    lifespan=_mcp_root_app.lifespan,
+)


### PR DESCRIPTION
### Motivation
- Smithery and other scanners observed `405`/`404` when sending MCP `initialize` POSTs because a GET-only root handler or mismatched routes could intercept or mis-dispatch requests destined for the MCP transport handler. 
- The server must present a canonical Streamable HTTP MCP endpoint at the root (`/`) while preserving legacy SSE compatibility at `/sse` and `/sse/` so scanners and clients can initialize reliably.

### Description
- Exposed a single canonical FastMCP `streamable-http` app at the root by mounting `_mcp_root_app = mcp.http_app(path="/", transport="streamable-http")` on `/` so `POST /` goes directly to the transport handler. 
- Added a small ASGI path-rewrite adapter `_PathRewriteApp` and mounted it at `/sse` so `/sse/` delegates to the same MCP root handler (rewriting the path to `/`).
- Added an explicit `Route` for exact `/sse` that returns a `307` redirect to `/sse/` to normalize non‑trailing‑slash requests and avoid accidental `404`/`405` responses. 
- Replaced the previous root GET info handler with `/.well-known/mcp/server-card.json` that advertises both `streamable-http` endpoints (`/` and `/sse/`) and kept `GET /healthz` for readiness checks, and updated `README.md` to reflect the new behavior.

### Testing
- Byte-compiled the changed modules with `python -m py_compile src/mcp_atomictoolkit/http_app.py main.py`, which succeeded. 
- Started the app locally with `PYTHONPATH=src uvicorn mcp_atomictoolkit.http_app:app --host 127.0.0.1 --port <PORT>` and observed successful startup. 
- Verified `GET /.well-known/mcp/server-card.json` returned HTTP `200` and the server-card advertises `http://<host>/` and `http://<host>/sse/`. 
- Verified `POST /` with MCP `initialize` payload returned `200` (streamable event response), `POST /sse` returned `307` redirect to `/sse/`, and `POST /sse/` returned `200` (all checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984429209f8832e88b31f8a1e7b57f4)