### PR TITLE
Improve Smithery capability discovery and make MCP responses scanner-friendly

### DIFF
--- a/src/mcp_atomictoolkit/http_app.py
+++ b/src/mcp_atomictoolkit/http_app.py
@@ -1,12 +1,33 @@
 from __future__ import annotations
 
+from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, RedirectResponse
+from starlette.routing import Mount, Route
 
 from mcp_atomictoolkit.mcp_server import mcp
 
 
-app = mcp.http_app(path="/sse", transport="sse")
+class _PathRewriteApp:
+    """ASGI adapter that rewrites incoming path before delegating."""
+
+    def __init__(self, app, target_path: str = "/") -> None:
+        self.app = app
+        self.target_path = target_path
+
+    async def __call__(self, scope, receive, send) -> None:
+        rewritten_scope = dict(scope)
+        rewritten_scope["path"] = self.target_path
+        rewritten_scope["raw_path"] = self.target_path.encode("utf-8")
+        await self.app(rewritten_scope, receive, send)
+
+
+# Primary MCP endpoint expected by Smithery and most registries.
+_mcp_root_app = mcp.http_app(
+    path="/",
+    transport="streamable-http",
+    json_response=True,
+)
 
 
 def _public_base_url(request: Request) -> str:
@@ -16,18 +37,6 @@ def _public_base_url(request: Request) -> str:
     if forwarded_proto and forwarded_host:
         return f"{forwarded_proto}://{forwarded_host}"
     return str(request.base_url).rstrip("/")
-
-
-async def handle_root(request: Request) -> JSONResponse:
-    base_url = _public_base_url(request)
-    return JSONResponse(
-        {
-            "name": "atomictoolkit",
-            "status": "ok",
-            "mcp_sse_url": f"{base_url}/sse",
-            "server_card_url": f"{base_url}/.well-known/mcp/server-card.json",
-        }
-    )
 
 
 async def handle_healthz(request: Request) -> JSONResponse:
@@ -42,16 +51,37 @@ async def handle_server_card(request: Request) -> JSONResponse:
             "name": "atomictoolkit",
             "description": "Atomistic simulation MCP server powered by ASE and MLIPs.",
             "version": "0.1.0",
+            "capabilities": {
+                "tools": {"listChanged": True},
+                "prompts": {"listChanged": True},
+                "resources": {"listChanged": True, "subscribe": False},
+            },
             "transports": [
                 {
-                    "type": "sse",
-                    "url": f"{base_url}/sse",
-                }
+                    "type": "streamable-http",
+                    "url": f"{base_url}/",
+                },
+                {
+                    "type": "streamable-http",
+                    "url": f"{base_url}/sse/",
+                },
             ],
         }
     )
 
 
-app.add_route("/", handle_root)
-app.add_route("/healthz", handle_healthz)
-app.add_route("/.well-known/mcp/server-card.json", handle_server_card)
+async def handle_sse_no_slash(request: Request):
+    """Normalize /sse -> /sse/ so the mounted compatibility app handles it."""
+    return RedirectResponse(url="/sse/", status_code=307)
+
+
+app = Starlette(
+    routes=[
+        Route("/healthz", handle_healthz),
+        Route("/.well-known/mcp/server-card.json", handle_server_card),
+        Route("/sse", handle_sse_no_slash, methods=["GET", "HEAD", "POST", "DELETE"]),
+        Mount("/sse", app=_PathRewriteApp(_mcp_root_app, target_path="/")),
+        Mount("/", app=_mcp_root_app),
+    ],
+    lifespan=_mcp_root_app.lifespan,
+)


### PR DESCRIPTION
### Motivation
- Scanners like Smithery reported "No capabilities found" because some discovery paths and response formats (SSE framing) were not presented in a scanner-friendly way. 
- The server should advertise capabilities in its server-card and support JSON-oriented clients during MCP `initialize` and follow-up calls. 

### Description
- Exposed the canonical FastMCP `streamable-http` app at the root with `json_response=True` by creating `_mcp_root_app = mcp.http_app(path="/", transport="streamable-http", json_response=True)` so JSON-capable clients can receive standard JSON responses. 
- Added an ASGI adapter `_PathRewriteApp` and mounted it at `/sse` with `Mount("/sse", app=_PathRewriteApp(_mcp_root_app, target_path="/"))` to preserve legacy `/sse/` compatibility while delegating to the root handler. 
- Added a redirect route for exact `/sse` to `/sse/` via `Route("/sse", handle_sse_no_slash, methods=[...])` to normalize non-trailing-slash requests and avoid accidental `404/405`. 
- Updated `/.well-known/mcp/server-card.json` to include an explicit `capabilities` object and to advertise the root `streamable-http` transport, and updated `README.md` guidance to reference the root MCP URL and transport. 

### Testing
- Byte-compiled the modified module with `python -m py_compile src/mcp_atomictoolkit/http_app.py`, which succeeded. 
- Started the app locally with `PYTHONPATH=src python -m uvicorn mcp_atomictoolkit.http_app:app --host 127.0.0.1 --port 18011` and the server started successfully. 
- Verified `GET /.well-known/mcp/server-card.json` returned HTTP `200` with the `capabilities` block and transport URLs, and `POST /` with `Accept: application/json` returned a `200` JSON initialize result. 
- Verified `POST /` followed by `tools/list` using the returned `mcp-session-id` returned `200` with a populated `tools` array (all checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984429209f8832e88b31f8a1e7b57f4)