### PR TITLE
Enable stateless Streamable HTTP MCP endpoint

### DIFF
--- a/src/mcp_atomictoolkit/http_app.py
+++ b/src/mcp_atomictoolkit/http_app.py
@@ -27,6 +27,7 @@ _mcp_root_app = mcp.http_app(
     path="/",
     transport="streamable-http",
     json_response=True,
+    stateless_http=True,
 )
 
 


### PR DESCRIPTION
### Motivation
- Directory scanners (e.g., Smithery) reported "No capabilities found" because the Streamable HTTP MCP endpoint required a preserved `mcp-session-id` across requests, which some probes do not maintain.

### Description
- Turn on stateless Streamable HTTP mode by adding `stateless_http=True` to `mcp.http_app(...)` in `src/mcp_atomictoolkit/http_app.py` so capability/tool discovery works without session affinity.

### Testing
- Started the app locally with `PYTHONPATH=src uvicorn mcp_atomictoolkit.http_app:app` and exercised the endpoint programmatically. 
- Sent a single `POST /` `tools/list` request with `Content-Type: application/json` and `Accept: application/json, text/event-stream` using `curl`, and received HTTP `200` with the full tool list in the JSON response.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69845648fbb4832ead0ea48d1fdefe30)