### PR TITLE
Improve MCP tool error observability in deployment logs

### DIFF
--- a/hf_server.py
+++ b/hf_server.py
@@ -1,4 +1,5 @@
 import os
+import logging
 
 import uvicorn
 
@@ -6,6 +7,11 @@ from mcp_atomictoolkit.http_app import app
 
 
 if __name__ == "__main__":
+    log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    )
     host = os.environ.get("HOST", "0.0.0.0")
     port = int(os.environ.get("PORT", "7860"))
-    uvicorn.run(app, host=host, port=port, log_level="info")
+    uvicorn.run(app, host=host, port=port, log_level=log_level.lower())

--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 import os
+import logging
 
 import uvicorn
 
@@ -6,6 +7,11 @@ from mcp_atomictoolkit.http_app import app
 
 
 if __name__ == "__main__":
+    log_level = os.environ.get("LOG_LEVEL", "INFO").upper()
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    )
     host = os.environ.get("HOST", "0.0.0.0")
     port = int(os.environ.get("PORT", "10000"))
-    uvicorn.run(app, host=host, port=port, log_level="info")
+    uvicorn.run(app, host=host, port=port, log_level=log_level.lower())


### PR DESCRIPTION
### Motivation
- Ensure runtime tool failures (e.g., energy or optimization errors) are visible in deployment logs with actionable context. 
- Avoid dumping oversized request payloads while preserving enough context to triage failures. 
- Align server logging and tool logging so logs from uvicorn and MCP tools are consistently visible in deployments.

### Description
- Add a module logger and `_compact_kwargs` in `src/mcp_atomictoolkit/mcp_server.py` to abbreviate long strings, large lists, and large dicts before logging. 
- Replace direct workflow calls with a centralized `_run_tool` wrapper that measures latency with `perf_counter`, logs start/success, and logs failures including the exception class, message, elapsed time, and compacted args. 
- Route core tool entrypoints (e.g., `build_structure_workflow`, `analyze_structure_workflow`, `run_md_workflow`, `optimize_structure_workflow`, `write_structure_workflow`, `analyze_trajectory_workflow`, `autocorrelation_workflow`) through `_run_tool`. 
- Update `main.py` and `hf_server.py` to derive `LOG_LEVEL` from the environment and pass it to both `logging.basicConfig` and `uvicorn.run` so server and tool logs are aligned.

### Testing
- Ran `python -m compileall src main.py hf_server.py` which completed successfully and confirmed the modified modules compile without syntax errors. 
- Verified the changes were limited to `src/mcp_atomictoolkit/mcp_server.py`, `main.py`, and `hf_server.py` and did not introduce import/compile-time failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984f393f534832ea0127eb25e8f3d94)