### PR TITLE
Fix MD trajectory writer, add configurable plot formats, and enrich server-card/artifact outputs

### DIFF
--- a/src/mcp_atomictoolkit/http_app.py
+++ b/src/mcp_atomictoolkit/http_app.py
@@ -92,12 +92,24 @@ async def handle_server_card(request: Request) -> JSONResponse:
     return JSONResponse(
         {
             "name": "atomictoolkit",
-            "description": "Atomistic simulation MCP server powered by ASE and MLIPs.",
+            "displayName": "Atomistic Toolkit MCP",
+            "description": "MCP server for atomistic structure generation, analysis, optimization, and molecular dynamics using ASE, pymatgen, Nequix, and Orb.",
             "version": "0.1.0",
+            "homepage": base_url,
+            "documentationUrl": f"{base_url}/.well-known/mcp/server-card.json",
+            "defaultTransport": {"type": "streamable-http", "url": f"{base_url}/"},
             "capabilities": {
                 "tools": {"listChanged": True},
                 "prompts": {"listChanged": True},
                 "resources": {"listChanged": True, "subscribe": False},
+            },
+            "tooling": {
+                "domains": ["materials-science", "atomistic-simulation"],
+                "artifactDownloadPath": f"{base_url}/artifacts/{{artifact_id}}/{{filename}}",
+                "artifactFormats": [
+                    "xyz", "extxyz", "traj", "cif", "vasp", "poscar",
+                    "png", "svg", "eps", "pdf", "csv", "dat", "txt", "json", "log"
+                ],
             },
             "transports": [
                 {

--- a/src/mcp_atomictoolkit/mcp_server.py
+++ b/src/mcp_atomictoolkit/mcp_server.py
@@ -116,6 +116,7 @@ async def analyze_structure_workflow(
     rdf_bins: int = 200,
     coordination_cutoff: Optional[float] = None,
     coordination_factor: float = 1.2,
+    plot_formats: Optional[List[str]] = None,
 ) -> Dict:
     """Analyze structure file and return metadata.
 
@@ -136,6 +137,7 @@ async def analyze_structure_workflow(
         rdf_bins=rdf_bins,
         coordination_cutoff=coordination_cutoff,
         coordination_factor=coordination_factor,
+        plot_formats=plot_formats,
     )
 
 
@@ -257,6 +259,7 @@ async def analyze_trajectory_workflow(
     rdf_max: float = 10.0,
     rdf_bins: int = 200,
     rdf_stride: int = 1,
+    plot_formats: Optional[List[str]] = None,
 ) -> Dict:
     """Analyze a trajectory and return analysis artifacts."""
     return _run_tool(
@@ -269,6 +272,7 @@ async def analyze_trajectory_workflow(
         rdf_max=rdf_max,
         rdf_bins=rdf_bins,
         rdf_stride=rdf_stride,
+        plot_formats=plot_formats,
     )
 
 
@@ -279,6 +283,7 @@ async def autocorrelation_workflow(
     output_dir: str = "analysis_outputs/autocorrelation",
     timestep_fs: float = 1.0,
     max_lag: Optional[int] = None,
+    plot_formats: Optional[List[str]] = None,
 ) -> Dict:
     """Autocorrelation workflow for VACF and diffusion."""
     return _run_tool(
@@ -289,6 +294,7 @@ async def autocorrelation_workflow(
         output_dir=output_dir,
         timestep_fs=timestep_fs,
         max_lag=max_lag,
+        plot_formats=plot_formats,
     )
 
 

--- a/src/mcp_atomictoolkit/md_runner.py
+++ b/src/mcp_atomictoolkit/md_runner.py
@@ -58,18 +58,25 @@ class MDSummary:
 
 
 def _attach_trajectory_writer(
-    atoms: Atoms, trajectory_path: Path, fmt: str, interval: int
+    md,
+    atoms: Atoms,
+    trajectory_path: Path,
+    fmt: str,
+    interval: int,
 ) -> None:
     """Attach a trajectory writer to the MD run."""
     if fmt == "traj":
         traj = Trajectory(str(trajectory_path), "w", atoms)
-        atoms.attach(traj.write, interval=interval)
+        md.attach(traj.write, interval=interval)
         return
+
+    if trajectory_path.exists():
+        trajectory_path.unlink()
 
     def _write_extxyz():
         write(str(trajectory_path), atoms, format=fmt, append=True)
 
-    atoms.attach(_write_extxyz, interval=interval)
+    md.attach(_write_extxyz, interval=interval)
 
 
 def _initialize_velocities(atoms: Atoms, temperature_K: float) -> None:
@@ -156,7 +163,13 @@ def run_md(
     trajectory_path = Path(output_trajectory_filepath)
     trajectory_path.parent.mkdir(parents=True, exist_ok=True)
     fmt = output_format or trajectory_path.suffix.lstrip(".") or "traj"
-    _attach_trajectory_writer(atoms, trajectory_path, fmt, trajectory_interval)
+    _attach_trajectory_writer(
+        md,
+        atoms,
+        trajectory_path,
+        fmt,
+        trajectory_interval,
+    )
 
     log_path = Path(log_filepath)
     log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/mcp_atomictoolkit/workflows/core.py
+++ b/src/mcp_atomictoolkit/workflows/core.py
@@ -64,6 +64,7 @@ def analyze_structure_workflow(
     rdf_bins: int = 200,
     coordination_cutoff: Optional[float] = None,
     coordination_factor: float = 1.2,
+    plot_formats: Optional[Sequence[str]] = None,
 ) -> Dict:
     """Analyze a structure file and return metadata and analysis artifacts."""
     analysis = analyze_structure(
@@ -74,6 +75,7 @@ def analyze_structure_workflow(
         rdf_bins=rdf_bins,
         coordination_cutoff=coordination_cutoff,
         coordination_factor=coordination_factor,
+        plot_formats=plot_formats,
     )
     structure = read_structure(filepath, format)
     return {
@@ -176,6 +178,7 @@ def analyze_trajectory_workflow(
     rdf_max: float = 10.0,
     rdf_bins: int = 200,
     rdf_stride: int = 1,
+    plot_formats: Optional[Sequence[str]] = None,
 ) -> Dict:
     """Analyze a trajectory and return analysis artifacts."""
     return analyze_trajectory(
@@ -186,6 +189,7 @@ def analyze_trajectory_workflow(
         rdf_max=rdf_max,
         rdf_bins=rdf_bins,
         rdf_stride=rdf_stride,
+        plot_formats=plot_formats,
     )
 
 
@@ -195,6 +199,7 @@ def autocorrelation_workflow(
     output_dir: str = "analysis_outputs/autocorrelation",
     timestep_fs: float = 1.0,
     max_lag: Optional[int] = None,
+    plot_formats: Optional[Sequence[str]] = None,
 ) -> Dict:
     """Compute VACF/autocorrelation analysis and diffusion coefficients."""
     return analyze_vacf(
@@ -203,4 +208,5 @@ def autocorrelation_workflow(
         output_dir=output_dir,
         timestep_fs=timestep_fs,
         max_lag=max_lag,
+        plot_formats=plot_formats,
     )


### PR DESCRIPTION
### Motivation
- Fix a runtime failure where MD trajectory writers were attached to `Atoms` instead of the MD integrator, and make figure outputs flexible for AI agents. 
- Ensure analysis tools produce downloadable artifacts in multiple formats (png/svg/eps/other matplotlib formats) so agents can request preferred figure types. 
- Improve MCP discovery and artifact conventions by enriching the server-card metadata so scanners and agents can understand artifact download locations and supported formats.

### Description
- Attach trajectory writers to the MD dynamics object and overwrite non-`.traj` output files before appending frames by updating `_attach_trajectory_writer` and its usage in `run_md` (file: `src/mcp_atomictoolkit/md_runner.py`).
- Add a `plot_formats` argument and export requested image formats for structure, trajectory, and autocorrelation analysis routines; include files and artifact paths for each requested format (files: `src/mcp_atomictoolkit/analysis/structure.py`, `src/mcp_atomictoolkit/analysis/trajectory.py`, `src/mcp_atomictoolkit/analysis/autocorrelation.py`).
- Thread `plot_formats` through workflows and MCP tool interfaces so agents can request formats via the MCP tools (files: `src/mcp_atomictoolkit/workflows/core.py`, `src/mcp_atomictoolkit/mcp_server.py`).
- Enrich the MCP server-card with `displayName`, `homepage`, `documentationUrl`, `defaultTransport`, and a `tooling` block that lists `artifactFormats` and `artifactDownloadPath` to clarify artifact conventions (file: `src/mcp_atomictoolkit/http_app.py`).

### Testing
- Ran `python -m compileall src` and it completed successfully.
- Ran `python -m py_compile` on the modified modules and they compiled without syntax errors.
- Attempted a lightweight workflow smoke test, but it could not run end-to-end due to the environment missing the `ase` package (`ModuleNotFoundError: No module named 'ase'`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698506f2cff0832eaa0f6929d1cde6fc)