### PR TITLE
Add structure HTML preview artifacts with download URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Set these in the Render UI if they were overridden:
 
 
 ### Downloadable artifacts (structures, plots, tables)
-All tools now return an `artifacts` list when output files are created (for example: `extxyz`, `traj`, `cif`, `png`, `svg`, `eps`, `csv`, `dat`). Each artifact includes a `download_url` that can be opened directly in Cursor/Claude clients without embedding binary data in chat context.
+All tools now return an `artifacts` list when output files are created (for example: `extxyz`, `traj`, `cif`, `png`, `svg`, `eps`, `csv`, `dat`). Each artifact includes a `download_url` that can be opened directly in Cursor/Claude clients without embedding binary data in chat context. For structure outputs (`xyz`, `extxyz`, `cif`, `vasp`, `poscar`), the server also emits a companion `html_preview` artifact that opens an interactive 3D browser view (3Dmol.js) of the structure.
 
 - Default URL shape: `/artifacts/<artifact_id>/<filename>`
 - Public absolute URLs: set `ARTIFACT_BASE_URL` (or `PUBLIC_BASE_URL`) to your Render URL, e.g. `https://<service>.onrender.com`


### PR DESCRIPTION
### Motivation
- Provide users an easy way to view generated structure files in-browser instead of only offering raw downloads. 
- Emit downloadable preview artifacts so MCP clients can present an interactive 3D view (viewer HTML) alongside structure files.

### Description
- Add `.html` to the recognized artifact suffixes and introduce `_STRUCTURE_SUFFIXES` for supported structure formats (`.xyz`, `.extxyz`, `.cif`, `.vasp`, `.poscar`).
- Implement `_write_structure_preview_html(structure_path: Path)` which writes a self-contained preview HTML that loads `3Dmol.js` and fetches the structure file next to it.
- After registering a discovered artifact, generate and register the companion preview page and append it to the returned `artifacts` list as `artifact_type: "html_preview"` with its `download_url` (respecting `ARTIFACT_BASE_URL` / `PUBLIC_BASE_URL`).
- Update `README.md` to document that structure outputs provide an additional `html_preview` artifact for interactive viewing.

### Testing
- Ran inline checks with `PYTHONPATH=src` that write temporary `tmp_test.xyz` and `tmp_test.cif`, call `with_downloadable_artifacts(...)`, and assert the result includes both a `structure` artifact and an `html_preview` artifact; the checks passed.
- Verified the generated preview HTML files are created and contain a 3Dmol.js-based viewer that fetches the sibling structure file; temporary files were removed after validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69850a0d1844832ea947851746ceb2b8)