### PR TITLE
Fix Matterviz HTML previews rendering as downloads

### DIFF
--- a/src/mcp_atomictoolkit/http_app.py
+++ b/src/mcp_atomictoolkit/http_app.py
@@ -158,16 +158,18 @@ async def handle_server_card(request: Request) -> JSONResponse:
 
 
 async def handle_artifact_download(request: Request):
-    """Serve generated artifacts as downloadable files."""
+    """Serve generated artifacts with disposition based on media type."""
     artifact_id = request.path_params["artifact_id"]
     record = artifact_store.get(artifact_id)
     if record is None or not record.filepath.exists():
         return JSONResponse({"error": "artifact_not_found", "artifact_id": artifact_id}, status_code=404)
 
+    is_html_preview = record.filepath.suffix.lower() == ".html"
     return FileResponse(
         path=record.filepath,
         filename=record.filepath.name,
-        content_disposition_type="attachment",
+        content_disposition_type="inline" if is_html_preview else "attachment",
+        media_type="text/html; charset=utf-8" if is_html_preview else None,
     )
 
 async def handle_sse_no_slash(request: Request):


### PR DESCRIPTION
### Motivation
- Matterviz-generated `.preview.html` files were being downloaded instead of rendered because the server returned them as attachments and the preview HTML fetched the structure via local `file://` paths causing CORS/local-file problems.

### Description
- Generate preview HTML that fetches the structure using its artifact URL (pass `rel_url` into `_write_structure_preview_html`) and JSON-encode the injected URL for safe JS embedding.
- Change `_write_structure_preview_html` signature to accept `structure_url` and import `json` to produce a `structure_url_literal` used in the generated markup.
- Update `with_downloadable_artifacts` to pass the artifact-relative URL when creating preview HTML and to register the generated preview file as an artifact.
- Serve `.html` artifacts inline by returning `FileResponse` with `content_disposition_type="inline"` and `media_type="text/html; charset=utf-8"`, while keeping non-HTML artifacts served as attachments.

### Testing
- Ran `python -m compileall src` and it completed successfully.
- Automated source checks confirmed the preview generator now has the signature `def _write_structure_preview_html(structure_path: Path, structure_url: str)` and that the generated HTML uses `fetch` with a JSON-encoded URL, and `http_app` uses inline disposition for HTML previews (assertions passed).
- Attempted an end-to-end `TestClient` request to validate response headers, but it could not be executed in this environment because the `starlette` dependency was not installed (test could not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69851588d8b8832e9080cf6deebdff5d)