### PR TITLE
fix: pin dm-tree to compiler-compatible release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "ase>=3.24.0",
+    "dm-tree>=0.1.6",
     "fastmcp>=2.14.5",
     "matplotlib>=3.9.0",
     "mcp[cli]>=1.4.1",


### PR DESCRIPTION
### Motivation
- CI builds were failing due to an Abseil/dm-tree compilation incompatibility with newer compilers, so the project dependency needs to require a dm-tree release that is compatible with modern toolchains.

### Description
- Add `dm-tree>=0.1.6` to `pyproject.toml` to ensure a compiler-compatible dm-tree is installed, and update `src/mcp_atomictoolkit.egg-info/requires.txt` to include the same dependency (the `pyproject.toml` change is committed).

### Testing
- Ran `python -m compileall -q src` which completed successfully, and validated changes with `git diff`/`git status` checks which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69851f869028832e9f68ff756cedb1d6)