### PR TITLE
Fix 3D preview initialization and default outputs to extxyz

### DIFF
--- a/src/mcp_atomictoolkit/artifact_store.py
+++ b/src/mcp_atomictoolkit/artifact_store.py
@@ -168,13 +168,23 @@ def _write_structure_preview_html(structure_path: Path, structure_url: str) -> O
   <div id=\"{container_id}\" class=\"viewer\"></div>
   <script>
     (async () => {{
+      const container = document.getElementById(\"{container_id}\");
+      if (!container) throw new Error(\"Viewer container not found\");
+
+      const canvas = document.createElement(\"canvas\");
+      const gl = canvas.getContext(\"webgl\") || canvas.getContext(\"experimental-webgl\");
+      if (!gl) {{
+        throw new Error(\"WebGL is unavailable in this environment, so the interactive viewer cannot be created.\");
+      }}
+
       const response = await fetch({structure_url_literal});
       if (!response.ok) throw new Error(`Failed to fetch structure file: ${{response.status}}`);
       const data = await response.text();
 
-      const viewer = $3Dmol.createViewer(document.getElementById(\"{container_id}\"), {{
+      const viewer = $3Dmol.createViewer(container, {{
         backgroundColor: \"white\"
       }});
+      if (!viewer) throw new Error(\"Failed to initialize 3Dmol viewer\");
       viewer.addModel(data, \"{parser_hint}\");
       viewer.setStyle({{}}, {{stick: {{}}, sphere: {{scale: 0.3}}}});
       viewer.zoomTo();

--- a/src/mcp_atomictoolkit/mcp_server.py
+++ b/src/mcp_atomictoolkit/mcp_server.py
@@ -68,7 +68,7 @@ async def build_structure_workflow(
     pbc: List[bool] = None,
     cell: Optional[List[List[float]]] = None,
     cell_size: Optional[List[float]] = None,
-    output_filepath: str = "structure.xyz",
+    output_filepath: str = "structure.extxyz",
     output_format: Optional[str] = None,
     builder_kwargs: Optional[Dict] = None,
 ) -> Dict:
@@ -176,7 +176,7 @@ async def write_structure_workflow(
 async def optimize_structure_workflow(
     input_filepath: str,
     input_format: Optional[str] = None,
-    output_filepath: str = "optimized.xyz",
+    output_filepath: str = "optimized.extxyz",
     output_format: Optional[str] = None,
     calculator_name: str = "nequix",
     max_steps: int = 50,
@@ -216,7 +216,7 @@ async def optimize_structure_workflow(
 async def run_md_workflow(
     input_filepath: str,
     input_format: Optional[str] = None,
-    output_trajectory_filepath: str = "md.traj",
+    output_trajectory_filepath: str = "md.extxyz",
     output_format: Optional[str] = None,
     log_filepath: str = "md.log",
     summary_filepath: str = "md_summary.txt",
@@ -307,7 +307,7 @@ async def build_structure(
     pbc: List[bool] = None,
     cell: Optional[List[List[float]]] = None,
     cell_size: Optional[List[float]] = None,
-    output_filepath: str = "structure.xyz",
+    output_filepath: str = "structure.extxyz",
     output_format: Optional[str] = None,
     builder_kwargs: Optional[Dict] = None,
 ) -> Dict:
@@ -354,7 +354,7 @@ async def write_structure_file(
 async def optimize_with_mlip(
     input_filepath: str,
     input_format: Optional[str] = None,
-    output_filepath: str = "optimized.xyz",
+    output_filepath: str = "optimized.extxyz",
     output_format: Optional[str] = None,
     calculator_name: str = "nequix",
     max_steps: int = 50,

--- a/src/mcp_atomictoolkit/md_runner.py
+++ b/src/mcp_atomictoolkit/md_runner.py
@@ -112,7 +112,7 @@ def _select_integrator(
 def run_md(
     input_filepath: str,
     input_format: Optional[str] = None,
-    output_trajectory_filepath: str = "md.traj",
+    output_trajectory_filepath: str = "md.extxyz",
     output_format: Optional[str] = None,
     log_filepath: str = "md.log",
     summary_filepath: str = "md_summary.txt",
@@ -162,7 +162,7 @@ def run_md(
 
     trajectory_path = Path(output_trajectory_filepath)
     trajectory_path.parent.mkdir(parents=True, exist_ok=True)
-    fmt = output_format or trajectory_path.suffix.lstrip(".") or "traj"
+    fmt = output_format or trajectory_path.suffix.lstrip(".") or "extxyz"
     _attach_trajectory_writer(
         md,
         atoms,

--- a/src/mcp_atomictoolkit/workflows/core.py
+++ b/src/mcp_atomictoolkit/workflows/core.py
@@ -24,7 +24,7 @@ def build_structure_workflow(
     pbc: Sequence[bool] = (True, True, True),
     cell: Optional[List[List[float]]] = None,
     cell_size: Optional[Sequence[float]] = None,
-    output_filepath: str = "structure.xyz",
+    output_filepath: str = "structure.extxyz",
     output_format: Optional[str] = None,
     builder_kwargs: Optional[Dict] = None,
 ) -> Dict:
@@ -107,7 +107,7 @@ def write_structure_workflow(
 def optimize_structure_workflow(
     input_filepath: str,
     input_format: Optional[str] = None,
-    output_filepath: str = "optimized.xyz",
+    output_filepath: str = "optimized.extxyz",
     output_format: Optional[str] = None,
     calculator_name: str = "nequix",
     max_steps: int = 50,
@@ -138,7 +138,7 @@ def optimize_structure_workflow(
 def run_md_workflow(
     input_filepath: str,
     input_format: Optional[str] = None,
-    output_trajectory_filepath: str = "md.traj",
+    output_trajectory_filepath: str = "md.extxyz",
     output_format: Optional[str] = None,
     log_filepath: str = "md.log",
     summary_filepath: str = "md_summary.txt",


### PR DESCRIPTION
### Motivation
- Prevent runtime errors when opening generated structure previews (e.g. `TypeError: Cannot read properties of null (reading 'clearDepth')`) by making the preview initialization more defensive.
- Default generated structure/trajectory outputs to extended XYZ (`.extxyz`) so richer metadata is preserved unless an explicit format is requested.

### Description
- Add defensive checks to the generated preview HTML in `_write_structure_preview_html` to ensure the viewer container exists, verify WebGL is available, and confirm the 3Dmol viewer was created before calling viewer methods (file: `src/mcp_atomictoolkit/artifact_store.py`).
- Change workflow and tool defaults from `.xyz`/`.traj` to `.extxyz` for structure and trajectory outputs (files: `src/mcp_atomictoolkit/workflows/core.py`, `src/mcp_atomictoolkit/mcp_server.py`).
- Update MD runner fallback behavior so the implicit fallback format is `extxyz` when no explicit format or recognizable extension is provided (file: `src/mcp_atomictoolkit/md_runner.py`).

### Testing
- Ran `python -m compileall -q src` successfully to validate syntax.
- Attempted `pytest -q` but tests could not run due to environment/dependency constraints (missing `matplotlib` and the project requires `Python >=3.13` while the environment is `3.10.19`).
- Project packaging/install via `pip install -r requirements.txt` could not complete for the same Python version constraint.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69851f24a1a4832e99b38f57168baa22)