### PR TITLE
ci: switch tests workflow to Python 3.11

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
### Motivation
- The CI job was failing because `dm-tree` cannot be built from source on Python 3.13 due to upstream C++/abseil compatibility, so the workflow should use a supported Python version.

### Description
- Updated `.github/workflows/tests.yml` to set `python-version: '3.11'` in the `Set up Python` step to avoid building `dm-tree` on an unsupported Python version.

### Testing
- Ran `git diff -- .github/workflows/tests.yml && git status --short` to verify the change is staged and visible, which succeeded. 
- Committed the change with message `ci: use Python 3.11 in tests workflow`, which succeeded. 
- Attempted to validate the YAML with a small Python snippet, but local validation failed because `PyYAML` is not installed; no full GitHub Actions run was executed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698523467c98832eaac48170f146877b)