### PR TITLE
Force JAX/Nequix to CPU and add regression tests

### DIFF
--- a/src/mcp_atomictoolkit/optimizers.py
+++ b/src/mcp_atomictoolkit/optimizers.py
@@ -18,9 +18,18 @@ NEQUIX_DEFAULT_BACKEND = "jax"
 
 
 def _configure_jax_for_cpu() -> None:
-    """Avoid JAX GPU/TPU plugin probing in CPU-only runtimes."""
-    os.environ.setdefault("JAX_PLATFORMS", "cpu")
-    os.environ.setdefault("JAX_PLATFORM_NAME", "cpu")
+    """Force JAX/Nequix execution on CPU-only runtimes."""
+    # We intentionally overwrite these values to guarantee CPU execution even
+    # when a hosting environment pre-sets GPU defaults.
+    os.environ["JAX_PLATFORMS"] = "cpu"
+    os.environ["JAX_PLATFORM_NAME"] = "cpu"
+    os.environ["CUDA_VISIBLE_DEVICES"] = ""
+    os.environ["JAX_CUDA_VISIBLE_DEVICES"] = ""
+
+
+# Configure CPU-only defaults as soon as this module is imported so that any
+# later JAX imports (triggered inside Nequix) inherit the safe environment.
+_configure_jax_for_cpu()
 
 
 def _normalize_calculator_name(calculator_name: str) -> str:

--- a/tests/test_optimizers_cpu_jax.py
+++ b/tests/test_optimizers_cpu_jax.py
@@ -1,0 +1,53 @@
+import importlib
+import sys
+import types
+
+
+def test_configure_jax_for_cpu_overrides_environment(monkeypatch):
+    monkeypatch.setenv("JAX_PLATFORMS", "cuda")
+    monkeypatch.setenv("JAX_PLATFORM_NAME", "gpu")
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
+    monkeypatch.setenv("JAX_CUDA_VISIBLE_DEVICES", "0")
+
+    sys.modules.pop("mcp_atomictoolkit.optimizers", None)
+    optimizers = importlib.import_module("mcp_atomictoolkit.optimizers")
+
+    assert optimizers.os.environ["JAX_PLATFORMS"] == "cpu"
+    assert optimizers.os.environ["JAX_PLATFORM_NAME"] == "cpu"
+    assert optimizers.os.environ["CUDA_VISIBLE_DEVICES"] == ""
+    assert optimizers.os.environ["JAX_CUDA_VISIBLE_DEVICES"] == ""
+
+
+def test_get_nequix_calculator_enforces_cpu_env(monkeypatch):
+    monkeypatch.setenv("JAX_PLATFORMS", "cuda")
+    monkeypatch.setenv("JAX_PLATFORM_NAME", "gpu")
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
+    monkeypatch.setenv("JAX_CUDA_VISIBLE_DEVICES", "0")
+
+    # Provide a lightweight fake nequix module so the test does not need the
+    # heavyweight dependency to be installed.
+    calculator_module = types.ModuleType("nequix.calculator")
+
+    class DummyNequixCalculator:
+        def __init__(self, model_name, backend):
+            self.model_name = model_name
+            self.backend = backend
+
+    calculator_module.NequixCalculator = DummyNequixCalculator
+
+    nequix_module = types.ModuleType("nequix")
+
+    monkeypatch.setitem(sys.modules, "nequix", nequix_module)
+    monkeypatch.setitem(sys.modules, "nequix.calculator", calculator_module)
+
+    sys.modules.pop("mcp_atomictoolkit.optimizers", None)
+    optimizers = importlib.import_module("mcp_atomictoolkit.optimizers")
+
+    calculator = optimizers.get_nequix_calculator()
+
+    assert isinstance(calculator, DummyNequixCalculator)
+    assert calculator.backend == "jax"
+    assert optimizers.os.environ["JAX_PLATFORMS"] == "cpu"
+    assert optimizers.os.environ["JAX_PLATFORM_NAME"] == "cpu"
+    assert optimizers.os.environ["CUDA_VISIBLE_DEVICES"] == ""
+    assert optimizers.os.environ["JAX_CUDA_VISIBLE_DEVICES"] == ""


### PR DESCRIPTION
### Motivation
- JAX was probing CUDA plugins in CPU-only deployments and failing with `cuInit` errors, so the toolkit must guarantee CPU-only execution to avoid runtime crashes when Nequix/JAX are imported.

### Description
- Overwrite environment variables to force CPU-only mode by setting `JAX_PLATFORMS`, `JAX_PLATFORM_NAME`, `CUDA_VISIBLE_DEVICES`, and `JAX_CUDA_VISIBLE_DEVICES` in `optimizers.py`.
- Invoke the CPU configuration at module import time so any later JAX/Nequix imports inherit the safe environment.
- Retain an explicit re-enforcement of CPU mode inside `get_nequix_calculator()` when the `jax` backend is requested.
- Add `tests/test_optimizers_cpu_jax.py` with two unit tests that use `monkeypatch` and a stubbed `nequix.calculator` to validate the environment overrides and the CPU enforcement behavior.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_optimizers_cpu_jax.py`, which executed 2 tests and passed.
- Ran `python -m compileall src/mcp_atomictoolkit/optimizers.py tests/test_optimizers_cpu_jax.py` and compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698536781e98832ea19579eb3066fc77)