### PR TITLE
Improve MCP tool error reporting and avoid invalid cubic defaults for hcp

### DIFF
--- a/src/mcp_atomictoolkit/structure_operations.py
+++ b/src/mcp_atomictoolkit/structure_operations.py
@@ -108,9 +108,14 @@ def create_structure(
     Returns:
         ASE Atoms object
     """
+    incompatible_cubic_crystals = {"hcp", "rhombohedral", "trigonal", "hexagonal"}
+    requested_cubic = kwargs.get("cubic")
+    default_cubic = crystal_system.lower() not in incompatible_cubic_crystals
+    use_cubic = default_cubic if requested_cubic is None else bool(requested_cubic)
+
     if structure_type == "bulk":
         atoms = bulk(
-            formula, crystal_system, a=lattice_constant, cubic=kwargs.get("cubic", True)
+            formula, crystal_system, a=lattice_constant, cubic=use_cubic
         )
         atoms.pbc = pbc
     elif structure_type == "molecule":
@@ -161,7 +166,7 @@ def create_structure(
         axis_map = {"x": 0, "y": 1, "z": 2}
         axis = axis_map.get(axis_label, 2)
         grain_a = bulk(
-            formula, crystal_system, a=lattice_constant, cubic=kwargs.get("cubic", True)
+            formula, crystal_system, a=lattice_constant, cubic=use_cubic
         )
         grain_a = grain_a * grain_size
         grain_b = grain_a.copy()
@@ -175,7 +180,7 @@ def create_structure(
         grain_size = kwargs.get("grain_size", (3, 3, 3))
         grid = int(np.ceil(num_grains ** (1 / 3)))
         base = bulk(
-            formula, crystal_system, a=lattice_constant, cubic=kwargs.get("cubic", True)
+            formula, crystal_system, a=lattice_constant, cubic=use_cubic
         )
         grains: List[Atoms] = []
         for idx in range(num_grains):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,22 @@
+from mcp_atomictoolkit.mcp_server import _run_tool
+
+
+def test_run_tool_returns_structured_error_payload() -> None:
+    def _boom(**_kwargs):
+        raise RuntimeError("Cannot create cubic cell for hcp structure")
+
+    result = _run_tool(
+        "build_structure_workflow",
+        _boom,
+        formula="Cu",
+        crystal_system="hcp",
+        builder_kwargs={"a": 2.556, "c": 4.174},
+    )
+
+    assert result["status"] == "error"
+    assert result["tool_name"] == "build_structure_workflow"
+    assert result["error"]["type"] == "RuntimeError"
+    assert "Cannot create cubic cell" in result["error"]["message"]
+    assert result["hints"]
+    assert "cubic" in result["hints"][0]
+    assert "Do not replace the workflow" in result["next_action"]

--- a/tests/test_structure_operations.py
+++ b/tests/test_structure_operations.py
@@ -52,6 +52,12 @@ def test_create_molecule_allows_custom_cell() -> None:
     assert atoms.cell.lengths().tolist() == pytest.approx([10, 10, 10])
 
 
+
+
+def test_create_bulk_hcp_defaults_to_non_cubic_cell() -> None:
+    atoms = create_structure("Cu", structure_type="bulk", crystal_system="hcp", lattice_constant=2.556, c=4.174)
+    assert len(atoms) > 0
+
 def test_manipulate_structure_translate_and_supercell() -> None:
     atoms = Atoms("H", positions=[[0, 0, 0]], cell=[5, 5, 5], pbc=[True, True, True])
     moved = manipulate_structure(atoms.copy(), "translate", vector=[1, 2, 3])


### PR DESCRIPTION
### Motivation
- Make MCP tool failures machine-actionable so the calling LLM/tooling receives structured error details and remediation hints instead of raw exceptions.
- Prevent a common false failure where bulk builders force `cubic=True` for non-cubic crystal systems (e.g. `hcp`), which raised `Cannot create cubic cell for hcp structure`.

### Description
- Return structured error payloads from `_run_tool` on exception containing `status`, `tool_name`, typed error metadata, `elapsed_ms`, `traceback`, compacted `inputs`, `hints`, and `next_action`, and augment outputs with downloadable artifact links via `with_downloadable_artifacts` (changes in `src/mcp_atomictoolkit/mcp_server.py`).
- Add `_error_hints` and `_tool_error_response` helpers and import `traceback` to generate contextual remediation hints for common failure modes (including targeted guidance for `hcp` + `cubic` issues and artifact-based MD/optimization workflows).
- Change bulk-structure creation defaults in `create_structure` so `cubic` is chosen based on `crystal_system` (disabling cubic for incompatible crystals such as `hcp`, `rhombohedral`, `trigonal`, `hexagonal`) while still allowing explicit override (changes in `src/mcp_atomictoolkit/structure_operations.py`).
- Add tests to cover the new behavior: `tests/test_mcp_server.py` verifies `_run_tool` returns a structured error payload with hints and next-action guidance, and `tests/test_structure_operations.py` adds a check that `hcp` bulk creation succeeds under the new default.

### Testing
- Running the focused test suite with `PYTHONPATH=src pytest -q tests/test_structure_operations.py tests/test_mcp_server.py` completed successfully (all tests passed).
- An initial `pytest -q` run failed in the environment due to a missing `matplotlib` dependency; dependency installation was performed and the focused tests were re-run and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69855ed85008832ebc7c8ba6d1a32824)