### PR TITLE
Stabilize test setup for missing matplotlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you need atomistic workflows exposed as MCP tools (instead of hand-wiring scr
 
 - **MCP-native workflows** via FastMCP tools
 - **Structure generation**: bulk, surface, molecule, supercell, amorphous, liquid, bicrystal, polycrystal
-- **Optimization workflows** with MLIPs (`nequix` default, `orb` supported)
+- **Optimization workflows** with MLIPs (`kim` default, `nequix`/`orb` supported)
 - **Molecular dynamics** workflows (Velocity Verlet, Langevin, NVT Berendsen)
 - **Analysis outputs**:
   - RDF + coordination stats

--- a/src/mcp_atomictoolkit/calculators.py
+++ b/src/mcp_atomictoolkit/calculators.py
@@ -1,0 +1,70 @@
+"""Calculator configuration helpers for MLIP backends."""
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nequix.calculator import NequixCalculator
+    from orb_models.forcefield.calculator import ORBCalculator
+
+NEQUIX_DEFAULT_MODEL = "nequix-mp-1"
+NEQUIX_DEFAULT_BACKEND = "jax"
+
+
+def _configure_jax_for_cpu() -> None:
+    """Force JAX/Nequix execution on CPU-only runtimes."""
+    # We intentionally overwrite these values to guarantee CPU execution even
+    # when a hosting environment pre-sets GPU defaults.
+    os.environ["JAX_PLATFORMS"] = "cpu"
+    os.environ["JAX_PLATFORM_NAME"] = "cpu"
+    os.environ["CUDA_VISIBLE_DEVICES"] = ""
+    os.environ["JAX_CUDA_VISIBLE_DEVICES"] = ""
+
+
+# Configure CPU-only defaults as soon as this module is imported so that any
+# later JAX imports (triggered inside Nequix) inherit the safe environment.
+_configure_jax_for_cpu()
+
+
+def _normalize_calculator_name(calculator_name: str) -> str:
+    """Return canonical calculator key, accepting common aliases/typos."""
+    aliases = {
+        "neqix": "nequix",
+    }
+    return aliases.get(calculator_name.lower(), calculator_name.lower())
+
+
+def get_orb_calculator() -> "ORBCalculator":
+    """Initialize Orb calculator."""
+    from orb_models.forcefield import pretrained
+    from orb_models.forcefield.calculator import ORBCalculator
+
+    orbff = pretrained.orb_v2(device="cpu")
+    calculator = ORBCalculator(orbff, device="cpu")
+    return calculator
+
+
+def get_nequix_calculator(
+    model_name: str = NEQUIX_DEFAULT_MODEL,
+    backend: str = NEQUIX_DEFAULT_BACKEND,
+) -> "NequixCalculator":
+    """Initialize Nequix calculator on CPU."""
+    if backend == "jax":
+        _configure_jax_for_cpu()
+
+    from nequix.calculator import NequixCalculator
+
+    return NequixCalculator(
+        model_name,
+        backend=backend,
+    )
+
+
+def get_calculator(calculator_name: str) -> "ORBCalculator | NequixCalculator":
+    """Return an ASE calculator for the requested MLIP."""
+    calculator_key = _normalize_calculator_name(calculator_name)
+    if calculator_key == "orb":
+        return get_orb_calculator()
+    if calculator_key == "nequix":
+        return get_nequix_calculator()
+    raise ValueError(f"Unknown MLIP type: {calculator_name}")

--- a/src/mcp_atomictoolkit/calculators.py
+++ b/src/mcp_atomictoolkit/calculators.py
@@ -12,6 +12,9 @@ if TYPE_CHECKING:
 NEQUIX_DEFAULT_MODEL = "nequix-mp-1"
 NEQUIX_DEFAULT_BACKEND = "jax"
 KIM_DEFAULT_MODEL = "LJ_ElliottAkerson_2015_Universal__MO_959249795837_003"
+# Default to the KIM pathway unless callers explicitly request a specific MLIP
+# (including the "orb of nequix" alias used when Orb is deemed superior).
+DEFAULT_CALCULATOR_NAME = "kim"
 
 
 def _configure_jax_for_cpu() -> None:
@@ -31,13 +34,16 @@ _configure_jax_for_cpu()
 
 def _normalize_calculator_name(calculator_name: str) -> str:
     """Return canonical calculator key, accepting common aliases/typos."""
+    normalized = calculator_name.strip().lower()
     aliases = {
         "neqix": "nequix",
+        "orb of nequix": "orb",
+        "orb-of-nequix": "orb",
         "openkim": "kim",
         "kim-model": "kim",
         "kim_model": "kim",
     }
-    return aliases.get(calculator_name.lower(), calculator_name.lower())
+    return aliases.get(normalized, normalized)
 
 
 def get_orb_calculator() -> "ORBCalculator":

--- a/src/mcp_atomictoolkit/calculators.py
+++ b/src/mcp_atomictoolkit/calculators.py
@@ -1,14 +1,17 @@
 """Calculator configuration helpers for MLIP backends."""
 
 import os
-from typing import TYPE_CHECKING
+import warnings
+from typing import TYPE_CHECKING, Sequence
 
 if TYPE_CHECKING:
     from nequix.calculator import NequixCalculator
     from orb_models.forcefield.calculator import ORBCalculator
+    from ase.calculators.kim.kim import KIM as KIMCalculator
 
 NEQUIX_DEFAULT_MODEL = "nequix-mp-1"
 NEQUIX_DEFAULT_BACKEND = "jax"
+KIM_DEFAULT_MODEL = "LJ_ElliottAkerson_2015_Universal__MO_959249795837_003"
 
 
 def _configure_jax_for_cpu() -> None:
@@ -30,6 +33,9 @@ def _normalize_calculator_name(calculator_name: str) -> str:
     """Return canonical calculator key, accepting common aliases/typos."""
     aliases = {
         "neqix": "nequix",
+        "openkim": "kim",
+        "kim-model": "kim",
+        "kim_model": "kim",
     }
     return aliases.get(calculator_name.lower(), calculator_name.lower())
 
@@ -60,11 +66,97 @@ def get_nequix_calculator(
     )
 
 
-def get_calculator(calculator_name: str) -> "ORBCalculator | NequixCalculator":
+def _normalize_species(species: Sequence[str] | None) -> list[str]:
+    """Return a sorted, unique list of chemical symbols."""
+    if not species:
+        return []
+    unique_species = {symbol for symbol in species if symbol}
+    return sorted(unique_species)
+
+
+def _select_kim_model_id(
+    species: Sequence[str] | None,
+) -> str:
+    """Select the first available KIM model ID for the given species."""
+    normalized_species = _normalize_species(species)
+    try:
+        from kim_query import get_available_models
+    except Exception as exc:
+        warnings.warn(
+            (
+                "kim-query is unavailable; falling back to the default KIM model "
+                f"'{KIM_DEFAULT_MODEL}'. Original error: {exc}"
+            ),
+            RuntimeWarning,
+        )
+        return KIM_DEFAULT_MODEL
+
+    if not normalized_species:
+        return KIM_DEFAULT_MODEL
+
+    try:
+        models = get_available_models(
+            species=normalized_species,
+            potential_type=["any"],
+        )
+    except Exception as exc:
+        warnings.warn(
+            (
+                "Failed to query OpenKIM models; falling back to the default KIM model "
+                f"'{KIM_DEFAULT_MODEL}'. Original error: {exc}"
+            ),
+            RuntimeWarning,
+        )
+        return KIM_DEFAULT_MODEL
+
+    if not models:
+        return KIM_DEFAULT_MODEL
+
+    first = models[0]
+    if isinstance(first, str):
+        return first
+    if isinstance(first, dict):
+        for key in ("model", "model_id", "kim_id", "extended_id", "id"):
+            value = first.get(key)
+            if value:
+                return value
+        return KIM_DEFAULT_MODEL
+    return str(first)
+
+
+def get_kim_calculator(
+    species: Sequence[str] | None = None,
+) -> "KIMCalculator":
+    """Initialize a KIM calculator for the requested species."""
+    model_id = _select_kim_model_id(species)
+    try:
+        from ase.calculators.kim.kim import KIM
+    except Exception as exc:
+        message = (
+            "Failed to import ASE KIM calculator. Ensure the KIM API and kimpy are "
+            "installed. See https://openkim.org/kim-api for installation instructions."
+        )
+        raise RuntimeError(message) from exc
+    try:
+        return KIM(model_id)
+    except Exception as exc:
+        message = (
+            f"Failed to initialize KIM model '{model_id}'. Ensure the KIM API and kimpy "
+            "are installed and that the model is available locally."
+        )
+        raise RuntimeError(message) from exc
+
+
+def get_calculator(
+    calculator_name: str,
+    species: Sequence[str] | None = None,
+) -> "ORBCalculator | NequixCalculator | KIMCalculator":
     """Return an ASE calculator for the requested MLIP."""
     calculator_key = _normalize_calculator_name(calculator_name)
     if calculator_key == "orb":
         return get_orb_calculator()
     if calculator_key == "nequix":
         return get_nequix_calculator()
+    if calculator_key == "kim":
+        return get_kim_calculator(species=species)
     raise ValueError(f"Unknown MLIP type: {calculator_name}")

--- a/src/mcp_atomictoolkit/mcp_server.py
+++ b/src/mcp_atomictoolkit/mcp_server.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, List, Optional
 from fastmcp import FastMCP
 
 from mcp_atomictoolkit.artifact_store import with_downloadable_artifacts
+from mcp_atomictoolkit.calculators import DEFAULT_CALCULATOR_NAME
 from mcp_atomictoolkit.workflows.core import (
     analyze_structure_workflow as analyze_structure_workflow_impl,
     analyze_trajectory_workflow as analyze_trajectory_workflow_impl,
@@ -215,7 +216,7 @@ async def optimize_structure_workflow(
     input_format: Optional[str] = None,
     output_filepath: str = "optimized.extxyz",
     output_format: Optional[str] = None,
-    calculator_name: str = "nequix",
+    calculator_name: str = DEFAULT_CALCULATOR_NAME,
     max_steps: int = 50,
     fmax: float = 0.1,
     constraints: Optional[Dict] = None,
@@ -227,7 +228,7 @@ async def optimize_structure_workflow(
         input_format: File format (optional)
         output_filepath: Output file path
         output_format: Output file format (optional)
-        calculator_name: Type of MLIP ('nequix' or 'orb')
+        calculator_name: Type of MLIP ('kim', 'nequix', or 'orb'). Defaults to KIM.
         max_steps: Maximum optimization steps
         fmax: Force convergence criterion
         constraints: Constraint settings (fixed atoms/cell/bonds)
@@ -257,7 +258,7 @@ async def run_md_workflow(
     output_format: Optional[str] = None,
     log_filepath: str = "md.log",
     summary_filepath: str = "md_summary.txt",
-    calculator_name: str = "nequix",
+    calculator_name: str = DEFAULT_CALCULATOR_NAME,
     integrator: str = "velocityverlet",
     timestep_fs: float = 1.0,
     temperature_K: float = 300.0,
@@ -393,7 +394,7 @@ async def optimize_with_mlip(
     input_format: Optional[str] = None,
     output_filepath: str = "optimized.extxyz",
     output_format: Optional[str] = None,
-    calculator_name: str = "nequix",
+    calculator_name: str = DEFAULT_CALCULATOR_NAME,
     max_steps: int = 50,
     fmax: float = 0.1,
     constraints: Optional[Dict] = None,

--- a/src/mcp_atomictoolkit/md_runner.py
+++ b/src/mcp_atomictoolkit/md_runner.py
@@ -19,7 +19,7 @@ from ase.md.verlet import VelocityVerlet
 from ase.md.logger import MDLogger
 
 from mcp_atomictoolkit.io_handlers import read_structure
-from mcp_atomictoolkit.optimizers import get_calculator
+from mcp_atomictoolkit.calculators import get_calculator
 
 
 @dataclass

--- a/src/mcp_atomictoolkit/md_runner.py
+++ b/src/mcp_atomictoolkit/md_runner.py
@@ -19,7 +19,7 @@ from ase.md.verlet import VelocityVerlet
 from ase.md.logger import MDLogger
 
 from mcp_atomictoolkit.io_handlers import read_structure
-from mcp_atomictoolkit.calculators import get_calculator
+from mcp_atomictoolkit.calculators import DEFAULT_CALCULATOR_NAME, get_calculator
 
 
 @dataclass
@@ -116,7 +116,7 @@ def run_md(
     output_format: Optional[str] = None,
     log_filepath: str = "md.log",
     summary_filepath: str = "md_summary.txt",
-    calculator_name: str = "nequix",
+    calculator_name: str = DEFAULT_CALCULATOR_NAME,
     integrator: str = "velocityverlet",
     timestep_fs: float = 1.0,
     temperature_K: float = 300.0,
@@ -134,7 +134,7 @@ def run_md(
         output_format: Trajectory format (optional, inferred from path).
         log_filepath: Path to log file for MD energies/temperature.
         summary_filepath: Path to summary file for MD statistics.
-        calculator_name: Type of MLIP ('nequix', 'orb', or 'kim').
+        calculator_name: Type of MLIP ('kim', 'nequix', or 'orb'). Defaults to KIM.
         integrator: Integrator ('velocityverlet', 'langevin', 'nvt').
         timestep_fs: MD timestep in femtoseconds.
         temperature_K: Target temperature in Kelvin.

--- a/src/mcp_atomictoolkit/md_runner.py
+++ b/src/mcp_atomictoolkit/md_runner.py
@@ -134,7 +134,7 @@ def run_md(
         output_format: Trajectory format (optional, inferred from path).
         log_filepath: Path to log file for MD energies/temperature.
         summary_filepath: Path to summary file for MD statistics.
-        calculator_name: Type of MLIP ('nequix' or 'orb').
+        calculator_name: Type of MLIP ('nequix', 'orb', or 'kim').
         integrator: Integrator ('velocityverlet', 'langevin', 'nvt').
         timestep_fs: MD timestep in femtoseconds.
         temperature_K: Target temperature in Kelvin.
@@ -147,7 +147,8 @@ def run_md(
         Dict containing output file paths and summary statistics.
     """
     atoms = read_structure(input_filepath, input_format)
-    atoms.calc = get_calculator(calculator_name)
+    species = sorted(set(atoms.get_chemical_symbols()))
+    atoms.calc = get_calculator(calculator_name, species=species)
 
     _initialize_velocities(atoms, temperature_K)
 

--- a/src/mcp_atomictoolkit/optimizers.py
+++ b/src/mcp_atomictoolkit/optimizers.py
@@ -1,79 +1,13 @@
 """Structure optimization using MLIPs (Orb and Nequix)."""
 
-import os
-
-from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 from ase import Atoms
 from ase.constraints import FixAtoms, FixBondLength, FixBondLengths
 from ase.optimize import BFGS
 
-if TYPE_CHECKING:
-    from nequix.calculator import NequixCalculator
-    from orb_models.forcefield.calculator import ORBCalculator
-
-NEQUIX_DEFAULT_MODEL = "nequix-mp-1"
-NEQUIX_DEFAULT_BACKEND = "jax"
-
-
-def _configure_jax_for_cpu() -> None:
-    """Force JAX/Nequix execution on CPU-only runtimes."""
-    # We intentionally overwrite these values to guarantee CPU execution even
-    # when a hosting environment pre-sets GPU defaults.
-    os.environ["JAX_PLATFORMS"] = "cpu"
-    os.environ["JAX_PLATFORM_NAME"] = "cpu"
-    os.environ["CUDA_VISIBLE_DEVICES"] = ""
-    os.environ["JAX_CUDA_VISIBLE_DEVICES"] = ""
-
-
-# Configure CPU-only defaults as soon as this module is imported so that any
-# later JAX imports (triggered inside Nequix) inherit the safe environment.
-_configure_jax_for_cpu()
-
-
-def _normalize_calculator_name(calculator_name: str) -> str:
-    """Return canonical calculator key, accepting common aliases/typos."""
-    aliases = {
-        "neqix": "nequix",
-    }
-    return aliases.get(calculator_name.lower(), calculator_name.lower())
-
-
-def get_orb_calculator() -> "ORBCalculator":
-    """Initialize Orb calculator."""
-    from orb_models.forcefield import pretrained
-    from orb_models.forcefield.calculator import ORBCalculator
-
-    orbff = pretrained.orb_v2(device="cpu")
-    calculator = ORBCalculator(orbff, device="cpu")
-    return calculator
-
-
-def get_nequix_calculator(
-    model_name: str = NEQUIX_DEFAULT_MODEL,
-    backend: str = NEQUIX_DEFAULT_BACKEND,
-) -> "NequixCalculator":
-    """Initialize Nequix calculator on CPU."""
-    if backend == "jax":
-        _configure_jax_for_cpu()
-
-    from nequix.calculator import NequixCalculator
-
-    return NequixCalculator(
-        model_name,
-        backend=backend,
-    )
-
-
-def get_calculator(calculator_name: str) -> "ORBCalculator | NequixCalculator":
-    """Return an ASE calculator for the requested MLIP."""
-    calculator_key = _normalize_calculator_name(calculator_name)
-    if calculator_key == "orb":
-        return get_orb_calculator()
-    if calculator_key == "nequix":
-        return get_nequix_calculator()
-    raise ValueError(f"Unknown MLIP type: {calculator_name}")
+from mcp_atomictoolkit.calculators import get_calculator
 
 
 def apply_constraints(atoms: Atoms, constraints: Optional[Dict[str, Any]]) -> None:

--- a/src/mcp_atomictoolkit/optimizers.py
+++ b/src/mcp_atomictoolkit/optimizers.py
@@ -1,4 +1,4 @@
-"""Structure optimization using MLIPs (Orb and Nequix)."""
+"""Structure optimization using MLIPs (KIM, Orb, and Nequix)."""
 
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -7,7 +7,7 @@ from ase import Atoms
 from ase.constraints import FixAtoms, FixBondLength, FixBondLengths
 from ase.optimize import BFGS
 
-from mcp_atomictoolkit.calculators import get_calculator
+from mcp_atomictoolkit.calculators import DEFAULT_CALCULATOR_NAME, get_calculator
 
 
 def apply_constraints(atoms: Atoms, constraints: Optional[Dict[str, Any]]) -> None:
@@ -51,7 +51,7 @@ def apply_constraints(atoms: Atoms, constraints: Optional[Dict[str, Any]]) -> No
 
 def optimize_structure(
     structure: Atoms,
-    calculator_name: str = "nequix",
+    calculator_name: str = DEFAULT_CALCULATOR_NAME,
     max_steps: int = 50,
     fmax: float = 0.1,
     constraints: Optional[Dict[str, Any]] = None,
@@ -61,7 +61,7 @@ def optimize_structure(
 
     Args:
         structure: Input structure
-        calculator_name: Type of MLIP ('nequix', 'orb', or 'kim')
+        calculator_name: Type of MLIP ('kim', 'nequix', or 'orb'). Defaults to KIM.
         max_steps: Maximum optimization steps
         fmax: Force convergence criterion
         constraints: Constraint settings (fixed atoms/cell/bonds)

--- a/src/mcp_atomictoolkit/optimizers.py
+++ b/src/mcp_atomictoolkit/optimizers.py
@@ -61,7 +61,7 @@ def optimize_structure(
 
     Args:
         structure: Input structure
-        calculator_name: Type of MLIP ('nequix' or 'orb')
+        calculator_name: Type of MLIP ('nequix', 'orb', or 'kim')
         max_steps: Maximum optimization steps
         fmax: Force convergence criterion
         constraints: Constraint settings (fixed atoms/cell/bonds)
@@ -75,7 +75,8 @@ def optimize_structure(
     apply_constraints(atoms, constraints)
 
     # Set up calculator
-    calculator = get_calculator(calculator_name)
+    species = sorted(set(atoms.get_chemical_symbols()))
+    calculator = get_calculator(calculator_name, species=species)
 
     atoms.calc = calculator
 

--- a/src/mcp_atomictoolkit/workflows/core.py
+++ b/src/mcp_atomictoolkit/workflows/core.py
@@ -10,6 +10,7 @@ from ase import Atoms
 from mcp_atomictoolkit.analysis.autocorrelation import analyze_vacf
 from mcp_atomictoolkit.analysis.structure import analyze_structure
 from mcp_atomictoolkit.analysis.trajectory import analyze_trajectory
+from mcp_atomictoolkit.calculators import DEFAULT_CALCULATOR_NAME
 from mcp_atomictoolkit.io_handlers import read_structure, write_structure
 from mcp_atomictoolkit.md_runner import run_md
 from mcp_atomictoolkit.optimizers import optimize_structure
@@ -109,7 +110,7 @@ def optimize_structure_workflow(
     input_format: Optional[str] = None,
     output_filepath: str = "optimized.extxyz",
     output_format: Optional[str] = None,
-    calculator_name: str = "nequix",
+    calculator_name: str = DEFAULT_CALCULATOR_NAME,
     max_steps: int = 50,
     fmax: float = 0.1,
     constraints: Optional[Dict] = None,
@@ -142,7 +143,7 @@ def run_md_workflow(
     output_format: Optional[str] = None,
     log_filepath: str = "md.log",
     summary_filepath: str = "md_summary.txt",
-    calculator_name: str = "nequix",
+    calculator_name: str = DEFAULT_CALCULATOR_NAME,
     integrator: str = "velocityverlet",
     timestep_fs: float = 1.0,
     temperature_K: float = 300.0,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,14 @@
-import matplotlib
+from pathlib import Path
+import sys
 
-matplotlib.use('Agg')
+ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+try:
+    import matplotlib
+except ModuleNotFoundError:
+    matplotlib = None
+else:
+    matplotlib.use("Agg")

--- a/tests/test_artifact_store.py
+++ b/tests/test_artifact_store.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import pytest
+
+from mcp_atomictoolkit import artifact_store
+
+
+def test_register_and_get_round_trip(tmp_path: Path) -> None:
+    sample = tmp_path / "sample.txt"
+    sample.write_text("data", encoding="utf-8")
+
+    record = artifact_store.artifact_store.register(sample)
+    fetched = artifact_store.artifact_store.get(record.artifact_id)
+
+    assert record.artifact_id.startswith("art_")
+    assert fetched == record
+    assert record.filepath == sample.resolve()
+
+
+def test_is_artifact_candidate_and_iter(tmp_path: Path) -> None:
+    allowed = tmp_path / "file.txt"
+    allowed.write_text("content", encoding="utf-8")
+    blocked = tmp_path / "file.bin"
+    blocked.write_bytes(b"binary")
+
+    assert artifact_store._is_artifact_candidate(str(allowed))
+    assert not artifact_store._is_artifact_candidate(str(blocked))
+
+    nested = {"a": str(allowed), "b": {"c": str(blocked)}}
+    found = list(artifact_store._iter_candidate_paths(nested))
+    assert found == [("a", str(allowed))]
+
+
+def test_with_downloadable_artifacts_adds_preview(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("ARTIFACT_BASE_URL", "https://example.test")
+
+    structure = tmp_path / "structure.xyz"
+    structure.write_text("1\nComment\nH 0 0 0\n", encoding="utf-8")
+
+    result = artifact_store.with_downloadable_artifacts({"structure": str(structure)})
+
+    assert "artifacts" in result
+    assert result["artifacts"][0]["download_url"].startswith("https://example.test/")
+    assert any(item["artifact_type"] == "html_preview" for item in result["artifacts"])
+    preview_path = Path(
+        next(item["filepath"] for item in result["artifacts"] if item["artifact_type"] == "html_preview")
+    )
+    assert preview_path.exists()
+
+
+def test_with_downloadable_artifacts_no_candidates() -> None:
+    result = artifact_store.with_downloadable_artifacts({"value": "not-a-path"})
+    assert result == {"value": "not-a-path"}
+
+
+def test_request_base_url_context_override() -> None:
+    token = artifact_store.set_request_base_url("https://example.test/base/")
+    try:
+        assert artifact_store._artifact_base_url() == "https://example.test/base"
+    finally:
+        artifact_store.reset_request_base_url(token)

--- a/tests/test_calculators_factory.py
+++ b/tests/test_calculators_factory.py
@@ -1,0 +1,90 @@
+import sys
+import types
+
+import pytest
+
+from mcp_atomictoolkit import calculators
+
+
+def _install_orb_stub(monkeypatch):
+    forcefield = types.ModuleType("orb_models.forcefield")
+    calculator_mod = types.ModuleType("orb_models.forcefield.calculator")
+
+    def orb_v2(device="cpu"):
+        return {"device": device}
+
+    class ORBCalculator:
+        def __init__(self, orbff, device="cpu"):
+            self.orbff = orbff
+            self.device = device
+
+    forcefield.pretrained = types.SimpleNamespace(orb_v2=orb_v2)
+    calculator_mod.ORBCalculator = ORBCalculator
+
+    monkeypatch.setitem(sys.modules, "orb_models.forcefield", forcefield)
+    monkeypatch.setitem(sys.modules, "orb_models.forcefield.calculator", calculator_mod)
+
+
+def _install_nequix_stub(monkeypatch):
+    nequix_calculator = types.ModuleType("nequix.calculator")
+
+    class NequixCalculator:
+        def __init__(self, model_name, backend="jax"):
+            self.model_name = model_name
+            self.backend = backend
+
+    nequix_calculator.NequixCalculator = NequixCalculator
+    monkeypatch.setitem(sys.modules, "nequix.calculator", nequix_calculator)
+
+
+def _install_kim_stub(monkeypatch):
+    kim_module = types.ModuleType("ase.calculators.kim.kim")
+
+    class KIM:
+        def __init__(self, model_id):
+            self.model_id = model_id
+
+    kim_module.KIM = KIM
+    monkeypatch.setitem(sys.modules, "ase.calculators.kim.kim", kim_module)
+
+
+def test_normalize_calculator_name_aliases():
+    assert calculators._normalize_calculator_name("neqix") == "nequix"
+    assert calculators._normalize_calculator_name("openkim") == "kim"
+    assert calculators._normalize_calculator_name("kim-model") == "kim"
+    assert calculators._normalize_calculator_name("orb") == "orb"
+
+
+def test_normalize_species_sorted_unique():
+    assert calculators._normalize_species(["W", "Al", "W"]) == ["Al", "W"]
+    assert calculators._normalize_species(None) == []
+
+
+def test_get_calculator_orb(monkeypatch):
+    _install_orb_stub(monkeypatch)
+    calculator = calculators.get_calculator("orb")
+    assert calculator.device == "cpu"
+    assert calculator.orbff["device"] == "cpu"
+
+
+def test_get_calculator_nequix(monkeypatch):
+    _install_nequix_stub(monkeypatch)
+    calculator = calculators.get_calculator("nequix")
+    assert calculator.model_name == calculators.NEQUIX_DEFAULT_MODEL
+
+
+def test_get_calculator_kim(monkeypatch):
+    _install_kim_stub(monkeypatch)
+    kim_query = types.ModuleType("kim_query")
+    kim_query.get_available_models = lambda species, potential_type: ["TEST_MODEL"]
+    monkeypatch.setitem(sys.modules, "kim_query", kim_query)
+
+    calculator = calculators.get_calculator("kim", species=["Al"])
+    assert calculator.model_id == "TEST_MODEL"
+
+
+def test_get_kim_calculator_import_error(monkeypatch):
+    monkeypatch.setitem(sys.modules, "ase.calculators.kim.kim", None)
+    monkeypatch.setitem(sys.modules, "kim_query", None)
+    with pytest.raises(RuntimeError, match="Failed to import ASE KIM calculator"):
+        calculators.get_kim_calculator(species=["Al"])

--- a/tests/test_calculators_kim.py
+++ b/tests/test_calculators_kim.py
@@ -1,0 +1,57 @@
+import sys
+import types
+
+import pytest
+
+from mcp_atomictoolkit import calculators
+
+
+def test_select_kim_model_id_uses_first_model(monkeypatch):
+    def fake_get_available_models(species, potential_type):
+        assert species == ["Al", "W"]
+        assert potential_type == ["any"]
+        return ["MODEL_1", "MODEL_2"]
+
+    monkeypatch.setitem(
+        sys.modules, "kim_query", types.SimpleNamespace(get_available_models=fake_get_available_models)
+    )
+
+    assert calculators._select_kim_model_id(["W", "Al"]) == "MODEL_1"
+
+
+def test_select_kim_model_id_handles_dict_result(monkeypatch):
+    def fake_get_available_models(species, potential_type):
+        assert species == ["Al"]
+        assert potential_type == ["any"]
+        return [{"model_id": "KIM_ID"}]
+
+    monkeypatch.setitem(
+        sys.modules, "kim_query", types.SimpleNamespace(get_available_models=fake_get_available_models)
+    )
+
+    assert calculators._select_kim_model_id(["Al"]) == "KIM_ID"
+
+
+def test_select_kim_model_id_warns_when_kim_query_missing(monkeypatch):
+    monkeypatch.setitem(sys.modules, "kim_query", None)
+
+    with pytest.warns(RuntimeWarning, match="kim-query is unavailable"):
+        assert (
+            calculators._select_kim_model_id(["Al"])
+            == calculators.KIM_DEFAULT_MODEL
+        )
+
+
+def test_select_kim_model_id_defaults_when_no_models(monkeypatch):
+    def fake_get_available_models(species, potential_type):
+        assert species == ["Al"]
+        assert potential_type == ["any"]
+        return []
+
+    monkeypatch.setitem(
+        sys.modules, "kim_query", types.SimpleNamespace(get_available_models=fake_get_available_models)
+    )
+
+    assert (
+        calculators._select_kim_model_id(["Al"]) == calculators.KIM_DEFAULT_MODEL
+    )

--- a/tests/test_http_app_utils.py
+++ b/tests/test_http_app_utils.py
@@ -1,0 +1,120 @@
+import importlib
+import sys
+import types
+
+
+def _load_http_app(monkeypatch):
+    starlette_applications = types.ModuleType("starlette.applications")
+    starlette_requests = types.ModuleType("starlette.requests")
+    starlette_responses = types.ModuleType("starlette.responses")
+    starlette_routing = types.ModuleType("starlette.routing")
+
+    class FakeStarlette:
+        def __init__(self, routes=None, lifespan=None):
+            self.routes = routes or []
+            self.lifespan = lifespan
+
+    class FakeRequest:
+        def __init__(self, headers, base_url="http://localhost/"):
+            self.headers = headers
+            self.base_url = base_url
+
+    class FakeResponse:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+
+    class FakeRoute:
+        def __init__(self, path, endpoint, methods=None):
+            self.path = path
+            self.endpoint = endpoint
+            self.methods = methods
+
+    class FakeMount:
+        def __init__(self, path, app):
+            self.path = path
+            self.app = app
+
+    starlette_applications.Starlette = FakeStarlette
+    starlette_requests.Request = FakeRequest
+    starlette_responses.FileResponse = FakeResponse
+    starlette_responses.JSONResponse = FakeResponse
+    starlette_responses.RedirectResponse = FakeResponse
+    starlette_routing.Route = FakeRoute
+    starlette_routing.Mount = FakeMount
+
+    monkeypatch.setitem(sys.modules, "starlette.applications", starlette_applications)
+    monkeypatch.setitem(sys.modules, "starlette.requests", starlette_requests)
+    monkeypatch.setitem(sys.modules, "starlette.responses", starlette_responses)
+    monkeypatch.setitem(sys.modules, "starlette.routing", starlette_routing)
+
+    mcp_server_stub = types.ModuleType("mcp_atomictoolkit.mcp_server")
+
+    class FakeMCP:
+        def http_app(self, **kwargs):
+            async def app(scope, receive, send):
+                return None
+
+            return app
+
+    mcp_server_stub.mcp = FakeMCP()
+    monkeypatch.setitem(sys.modules, "mcp_atomictoolkit.mcp_server", mcp_server_stub)
+
+    sys.modules.pop("mcp_atomictoolkit.http_app", None)
+    return importlib.import_module("mcp_atomictoolkit.http_app")
+
+
+def test_accept_header_compat_adds_json(monkeypatch):
+    http_app = _load_http_app(monkeypatch)
+
+    seen = {}
+
+    async def app(scope, receive, send):
+        seen["headers"] = scope.get("headers", [])
+
+    wrapper = http_app._AcceptHeaderCompatApp(app)
+    scope = {
+        "type": "http",
+        "headers": [(b"host", b"example.test")],
+    }
+
+    import asyncio
+
+    asyncio.run(wrapper(scope, None, None))
+    assert any(name == b"accept" for name, _ in seen["headers"])
+
+
+def test_accept_header_compat_replaces_invalid(monkeypatch):
+    http_app = _load_http_app(monkeypatch)
+
+    seen = {}
+
+    async def app(scope, receive, send):
+        seen["headers"] = scope.get("headers", [])
+
+    wrapper = http_app._AcceptHeaderCompatApp(app)
+    scope = {
+        "type": "http",
+        "headers": [(b"accept", b"text/plain")],
+    }
+
+    import asyncio
+
+    asyncio.run(wrapper(scope, None, None))
+    accept = dict(seen["headers"]).get(b"accept")
+    assert accept == b"application/json, text/event-stream"
+
+
+def test_public_base_url_prefers_forwarded_headers(monkeypatch):
+    http_app = _load_http_app(monkeypatch)
+    request = http_app.Request(
+        {"x-forwarded-proto": "https", "x-forwarded-host": "example.test"},
+        base_url="http://ignored/",
+    )
+    assert http_app._public_base_url(request) == "https://example.test"
+
+
+def test_public_base_url_falls_back_to_request_base(monkeypatch):
+    http_app = _load_http_app(monkeypatch)
+    request = http_app.Request({}, base_url="http://local.test/root/")
+    assert http_app._public_base_url(request) == "http://local.test/root"

--- a/tests/test_io_handlers_branches.py
+++ b/tests/test_io_handlers_branches.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+import importlib
+import sys
+import types
+
+import pytest
+
+
+def _load_io_handlers(monkeypatch):
+    ase_stub = types.ModuleType("ase")
+    ase_io_stub = types.ModuleType("ase.io")
+    ase_stub.Atoms = object
+    ase_io_stub.read = lambda *args, **kwargs: None
+    ase_io_stub.write = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "ase", ase_stub)
+    monkeypatch.setitem(sys.modules, "ase.io", ase_io_stub)
+    sys.modules.pop("mcp_atomictoolkit.io_handlers", None)
+    return importlib.import_module("mcp_atomictoolkit.io_handlers")
+
+
+def test_read_structure_missing_file(monkeypatch, tmp_path: Path) -> None:
+    io_handlers = _load_io_handlers(monkeypatch)
+    with pytest.raises(FileNotFoundError):
+        io_handlers.read_structure(tmp_path / "missing.xyz")
+
+
+def test_read_structure_uses_extension(monkeypatch, tmp_path: Path) -> None:
+    io_handlers = _load_io_handlers(monkeypatch)
+    sample = tmp_path / "sample.xyz"
+    sample.write_text("data", encoding="utf-8")
+
+    captured = {}
+
+    def fake_read(filepath, format=None):
+        captured["filepath"] = filepath
+        captured["format"] = format
+        return "atoms"
+
+    monkeypatch.setattr(io_handlers, "read", fake_read)
+
+    atoms = io_handlers.read_structure(sample)
+
+    assert atoms == "atoms"
+    assert captured["format"] == "xyz"
+
+
+def test_read_structure_raises_value_error(monkeypatch, tmp_path: Path) -> None:
+    io_handlers = _load_io_handlers(monkeypatch)
+    sample = tmp_path / "sample.xyz"
+    sample.write_text("data", encoding="utf-8")
+
+    def fake_read(filepath, format=None):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(io_handlers, "read", fake_read)
+
+    with pytest.raises(ValueError, match="Failed to read file"):
+        io_handlers.read_structure(sample)
+
+
+def test_write_structure_uses_extension(monkeypatch, tmp_path: Path) -> None:
+    io_handlers = _load_io_handlers(monkeypatch)
+    captured = {}
+
+    def fake_write(filepath, atoms, format=None, **kwargs):
+        captured["filepath"] = filepath
+        captured["format"] = format
+        captured["atoms"] = atoms
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(io_handlers, "write", fake_write)
+
+    io_handlers.write_structure("atoms", tmp_path / "output.xyz")
+
+    assert captured["format"] == "xyz"
+
+
+def test_write_structure_raises_value_error(monkeypatch, tmp_path: Path) -> None:
+    io_handlers = _load_io_handlers(monkeypatch)
+    def fake_write(filepath, atoms, format=None, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(io_handlers, "write", fake_write)
+
+    with pytest.raises(ValueError, match="Failed to write file"):
+        io_handlers.write_structure("atoms", tmp_path / "output.xyz")

--- a/tests/test_kim_integration.py
+++ b/tests/test_kim_integration.py
@@ -1,0 +1,43 @@
+import pytest
+from ase import Atoms
+
+from mcp_atomictoolkit import calculators
+
+
+def test_ase_kim_uses_first_model_for_si():
+    kim_query = pytest.importorskip("kim_query")
+    pytest.importorskip("ase.calculators.kim.kim")
+
+    try:
+        models = kim_query.get_available_models(species=["Si"], potential_type=["any"])
+    except Exception as exc:
+        pytest.skip(f"OpenKIM query failed: {exc}")
+    if not models:
+        pytest.skip("OpenKIM query returned no models for Si.")
+
+    def _coerce_model_id(entry):
+        if isinstance(entry, str):
+            return entry
+        if isinstance(entry, dict):
+            for key in ("model", "model_id", "kim_id", "extended_id", "id"):
+                value = entry.get(key)
+                if value:
+                    return value
+        return str(entry)
+
+    first_model_id = _coerce_model_id(models[0])
+    model_id = calculators._select_kim_model_id(["Si"])
+    if model_id == calculators.KIM_DEFAULT_MODEL:
+        pytest.skip("No OpenKIM models discovered for Si.")
+    assert model_id == first_model_id
+
+    calc = calculators.get_kim_calculator(species=["Si"])
+    atoms = Atoms("Si2", positions=[[0, 0, 0], [2.35, 0, 0]], cell=[10, 10, 10], pbc=True)
+    atoms.calc = calc
+
+    try:
+        energy = atoms.get_potential_energy()
+    except Exception as exc:
+        pytest.skip(f"ASE KIM model could not compute energy: {exc}")
+
+    assert energy is not None

--- a/tests/test_mcp_server_utils.py
+++ b/tests/test_mcp_server_utils.py
@@ -1,0 +1,105 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+def _load_mcp_server(monkeypatch):
+    fastmcp_stub = types.ModuleType("fastmcp")
+
+    class FakeFastMCP:
+        def __init__(self, name: str):
+            self.name = name
+
+        def tool(self):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def http_app(self, **kwargs):
+            async def app(scope, receive, send):
+                return None
+
+            return app
+
+    fastmcp_stub.FastMCP = FakeFastMCP
+    monkeypatch.setitem(sys.modules, "fastmcp", fastmcp_stub)
+
+    workflows_stub = types.ModuleType("mcp_atomictoolkit.workflows.core")
+    for name in (
+        "analyze_structure_workflow",
+        "analyze_trajectory_workflow",
+        "autocorrelation_workflow",
+        "build_structure_workflow",
+        "optimize_structure_workflow",
+        "run_md_workflow",
+        "write_structure_workflow",
+    ):
+        setattr(
+            workflows_stub,
+            name,
+            lambda _name=name, **kwargs: {"status": "ok", "name": _name},
+        )
+    monkeypatch.setitem(sys.modules, "mcp_atomictoolkit.workflows.core", workflows_stub)
+
+    sys.modules.pop("mcp_atomictoolkit.mcp_server", None)
+    return importlib.import_module("mcp_atomictoolkit.mcp_server")
+
+
+def test_compact_kwargs_truncates(monkeypatch):
+    mcp_server = _load_mcp_server(monkeypatch)
+    data = {
+        "long_str": "a" * 201,
+        "long_list": list(range(26)),
+        "long_dict": {str(i): i for i in range(26)},
+        "short": "ok",
+    }
+    compacted = mcp_server._compact_kwargs(data)
+    assert compacted["long_str"] == "<str:201 chars>"
+    assert compacted["long_list"] == "<list:26 items>"
+    assert compacted["long_dict"] == "<dict:26 keys>"
+    assert compacted["short"] == "ok"
+
+
+def test_error_hints_for_hcp(monkeypatch):
+    mcp_server = _load_mcp_server(monkeypatch)
+    hints = mcp_server._error_hints(
+        "build_structure_workflow",
+        {"crystal_system": "hcp", "builder_kwargs": {}},
+        ValueError("Cubic lattice mismatch"),
+    )
+    assert any("hcp is not a cubic lattice" in hint for hint in hints)
+
+
+def test_tool_error_response_includes_hints(monkeypatch):
+    mcp_server = _load_mcp_server(monkeypatch)
+    response = mcp_server._tool_error_response(
+        "run_md_workflow",
+        FileNotFoundError("file not found"),
+        12.3,
+        {"input_filepath": "missing.xyz"},
+    )
+    assert response["status"] == "error"
+    assert response["tool_name"] == "run_md_workflow"
+    assert response["error"]["type"] == "FileNotFoundError"
+    assert any("Verify file paths" in hint for hint in response["hints"])
+    assert any("Use returned artifact download_url links" in hint for hint in response["hints"])
+
+
+def test_run_tool_success_and_failure(monkeypatch):
+    mcp_server = _load_mcp_server(monkeypatch)
+
+    def ok_tool():
+        return {"status": "ok"}
+
+    def bad_tool():
+        raise RuntimeError("boom")
+
+    ok_result = mcp_server._run_tool("ok_tool", ok_tool)
+    assert ok_result["status"] == "ok"
+
+    bad_result = mcp_server._run_tool("bad_tool", bad_tool)
+    assert bad_result["status"] == "error"
+    assert bad_result["tool_name"] == "bad_tool"

--- a/tests/test_optimizers_cpu_jax.py
+++ b/tests/test_optimizers_cpu_jax.py
@@ -9,13 +9,13 @@ def test_configure_jax_for_cpu_overrides_environment(monkeypatch):
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0")
     monkeypatch.setenv("JAX_CUDA_VISIBLE_DEVICES", "0")
 
-    sys.modules.pop("mcp_atomictoolkit.optimizers", None)
-    optimizers = importlib.import_module("mcp_atomictoolkit.optimizers")
+    sys.modules.pop("mcp_atomictoolkit.calculators", None)
+    calculators = importlib.import_module("mcp_atomictoolkit.calculators")
 
-    assert optimizers.os.environ["JAX_PLATFORMS"] == "cpu"
-    assert optimizers.os.environ["JAX_PLATFORM_NAME"] == "cpu"
-    assert optimizers.os.environ["CUDA_VISIBLE_DEVICES"] == ""
-    assert optimizers.os.environ["JAX_CUDA_VISIBLE_DEVICES"] == ""
+    assert calculators.os.environ["JAX_PLATFORMS"] == "cpu"
+    assert calculators.os.environ["JAX_PLATFORM_NAME"] == "cpu"
+    assert calculators.os.environ["CUDA_VISIBLE_DEVICES"] == ""
+    assert calculators.os.environ["JAX_CUDA_VISIBLE_DEVICES"] == ""
 
 
 def test_get_nequix_calculator_enforces_cpu_env(monkeypatch):
@@ -40,14 +40,14 @@ def test_get_nequix_calculator_enforces_cpu_env(monkeypatch):
     monkeypatch.setitem(sys.modules, "nequix", nequix_module)
     monkeypatch.setitem(sys.modules, "nequix.calculator", calculator_module)
 
-    sys.modules.pop("mcp_atomictoolkit.optimizers", None)
-    optimizers = importlib.import_module("mcp_atomictoolkit.optimizers")
+    sys.modules.pop("mcp_atomictoolkit.calculators", None)
+    calculators = importlib.import_module("mcp_atomictoolkit.calculators")
 
-    calculator = optimizers.get_nequix_calculator()
+    calculator = calculators.get_nequix_calculator()
 
     assert isinstance(calculator, DummyNequixCalculator)
     assert calculator.backend == "jax"
-    assert optimizers.os.environ["JAX_PLATFORMS"] == "cpu"
-    assert optimizers.os.environ["JAX_PLATFORM_NAME"] == "cpu"
-    assert optimizers.os.environ["CUDA_VISIBLE_DEVICES"] == ""
-    assert optimizers.os.environ["JAX_CUDA_VISIBLE_DEVICES"] == ""
+    assert calculators.os.environ["JAX_PLATFORMS"] == "cpu"
+    assert calculators.os.environ["JAX_PLATFORM_NAME"] == "cpu"
+    assert calculators.os.environ["CUDA_VISIBLE_DEVICES"] == ""
+    assert calculators.os.environ["JAX_CUDA_VISIBLE_DEVICES"] == ""


### PR DESCRIPTION
### Motivation
- Ensure the test suite can reliably import the local package and run in environments where `matplotlib` is not installed by making the test initialization resilient to import-time failures and import-path issues.

### Description
- Update `tests/conftest.py` to prepend the `src` directory to `sys.path` so tests can import the package, and make the `matplotlib` import optional while still setting the `Agg` backend when available.

### Testing
- Ran `pytest tests/test_optimizers_cpu_jax.py` and the suite completed successfully with `2 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698642e34220832eb1e81690db2c398b)