### PR TITLE
Prefer KIM calculator as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you need atomistic workflows exposed as MCP tools (instead of hand-wiring scr
 
 - **MCP-native workflows** via FastMCP tools
 - **Structure generation**: bulk, surface, molecule, supercell, amorphous, liquid, bicrystal, polycrystal
-- **Optimization workflows** with MLIPs (`nequix` default, `orb` supported)
+- **Optimization workflows** with MLIPs (`kim` default, `nequix`/`orb` supported)
 - **Molecular dynamics** workflows (Velocity Verlet, Langevin, NVT Berendsen)
 - **Analysis outputs**:
   - RDF + coordination stats

--- a/src/mcp_atomictoolkit/calculators.py
+++ b/src/mcp_atomictoolkit/calculators.py
@@ -12,6 +12,9 @@ if TYPE_CHECKING:
 NEQUIX_DEFAULT_MODEL = "nequix-mp-1"
 NEQUIX_DEFAULT_BACKEND = "jax"
 KIM_DEFAULT_MODEL = "LJ_ElliottAkerson_2015_Universal__MO_959249795837_003"
+# Default to the KIM pathway unless callers explicitly request a specific MLIP
+# (including the "orb of nequix" alias used when Orb is deemed superior).
+DEFAULT_CALCULATOR_NAME = "kim"
 
 
 def _configure_jax_for_cpu() -> None:
@@ -31,13 +34,16 @@ _configure_jax_for_cpu()
 
 def _normalize_calculator_name(calculator_name: str) -> str:
     """Return canonical calculator key, accepting common aliases/typos."""
+    normalized = calculator_name.strip().lower()
     aliases = {
         "neqix": "nequix",
+        "orb of nequix": "orb",
+        "orb-of-nequix": "orb",
         "openkim": "kim",
         "kim-model": "kim",
         "kim_model": "kim",
     }
-    return aliases.get(calculator_name.lower(), calculator_name.lower())
+    return aliases.get(normalized, normalized)
 
 
 def get_orb_calculator() -> "ORBCalculator":

--- a/src/mcp_atomictoolkit/mcp_server.py
+++ b/src/mcp_atomictoolkit/mcp_server.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, List, Optional
 from fastmcp import FastMCP
 
 from mcp_atomictoolkit.artifact_store import with_downloadable_artifacts
+from mcp_atomictoolkit.calculators import DEFAULT_CALCULATOR_NAME
 from mcp_atomictoolkit.workflows.core import (
     analyze_structure_workflow as analyze_structure_workflow_impl,
     analyze_trajectory_workflow as analyze_trajectory_workflow_impl,
@@ -215,7 +216,7 @@ async def optimize_structure_workflow(
     input_format: Optional[str] = None,
     output_filepath: str = "optimized.extxyz",
     output_format: Optional[str] = None,
-    calculator_name: str = "nequix",
+    calculator_name: str = DEFAULT_CALCULATOR_NAME,
     max_steps: int = 50,
     fmax: float = 0.1,
     constraints: Optional[Dict] = None,
@@ -227,7 +228,7 @@ async def optimize_structure_workflow(
         input_format: File format (optional)
         output_filepath: Output file path
         output_format: Output file format (optional)
-        calculator_name: Type of MLIP ('nequix' or 'orb')
+        calculator_name: Type of MLIP ('kim', 'nequix', or 'orb'). Defaults to KIM.
         max_steps: Maximum optimization steps
         fmax: Force convergence criterion
         constraints: Constraint settings (fixed atoms/cell/bonds)
@@ -257,7 +258,7 @@ async def run_md_workflow(
     output_format: Optional[str] = None,
     log_filepath: str = "md.log",
     summary_filepath: str = "md_summary.txt",
-    calculator_name: str = "nequix",
+    calculator_name: str = DEFAULT_CALCULATOR_NAME,
     integrator: str = "velocityverlet",
     timestep_fs: float = 1.0,
     temperature_K: float = 300.0,
@@ -393,7 +394,7 @@ async def optimize_with_mlip(
     input_format: Optional[str] = None,
     output_filepath: str = "optimized.extxyz",
     output_format: Optional[str] = None,
-    calculator_name: str = "nequix",
+    calculator_name: str = DEFAULT_CALCULATOR_NAME,
     max_steps: int = 50,
     fmax: float = 0.1,
     constraints: Optional[Dict] = None,

--- a/src/mcp_atomictoolkit/md_runner.py
+++ b/src/mcp_atomictoolkit/md_runner.py
@@ -19,7 +19,7 @@ from ase.md.verlet import VelocityVerlet
 from ase.md.logger import MDLogger
 
 from mcp_atomictoolkit.io_handlers import read_structure
-from mcp_atomictoolkit.calculators import get_calculator
+from mcp_atomictoolkit.calculators import DEFAULT_CALCULATOR_NAME, get_calculator
 
 
 @dataclass
@@ -116,7 +116,7 @@ def run_md(
     output_format: Optional[str] = None,
     log_filepath: str = "md.log",
     summary_filepath: str = "md_summary.txt",
-    calculator_name: str = "nequix",
+    calculator_name: str = DEFAULT_CALCULATOR_NAME,
     integrator: str = "velocityverlet",
     timestep_fs: float = 1.0,
     temperature_K: float = 300.0,
@@ -134,7 +134,7 @@ def run_md(
         output_format: Trajectory format (optional, inferred from path).
         log_filepath: Path to log file for MD energies/temperature.
         summary_filepath: Path to summary file for MD statistics.
-        calculator_name: Type of MLIP ('nequix', 'orb', or 'kim').
+        calculator_name: Type of MLIP ('kim', 'nequix', or 'orb'). Defaults to KIM.
         integrator: Integrator ('velocityverlet', 'langevin', 'nvt').
         timestep_fs: MD timestep in femtoseconds.
         temperature_K: Target temperature in Kelvin.

--- a/src/mcp_atomictoolkit/optimizers.py
+++ b/src/mcp_atomictoolkit/optimizers.py
@@ -1,4 +1,4 @@
-"""Structure optimization using MLIPs (Orb and Nequix)."""
+"""Structure optimization using MLIPs (KIM, Orb, and Nequix)."""
 
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -7,7 +7,7 @@ from ase import Atoms
 from ase.constraints import FixAtoms, FixBondLength, FixBondLengths
 from ase.optimize import BFGS
 
-from mcp_atomictoolkit.calculators import get_calculator
+from mcp_atomictoolkit.calculators import DEFAULT_CALCULATOR_NAME, get_calculator
 
 
 def apply_constraints(atoms: Atoms, constraints: Optional[Dict[str, Any]]) -> None:
@@ -51,7 +51,7 @@ def apply_constraints(atoms: Atoms, constraints: Optional[Dict[str, Any]]) -> No
 
 def optimize_structure(
     structure: Atoms,
-    calculator_name: str = "nequix",
+    calculator_name: str = DEFAULT_CALCULATOR_NAME,
     max_steps: int = 50,
     fmax: float = 0.1,
     constraints: Optional[Dict[str, Any]] = None,
@@ -61,7 +61,7 @@ def optimize_structure(
 
     Args:
         structure: Input structure
-        calculator_name: Type of MLIP ('nequix', 'orb', or 'kim')
+        calculator_name: Type of MLIP ('kim', 'nequix', or 'orb'). Defaults to KIM.
         max_steps: Maximum optimization steps
         fmax: Force convergence criterion
         constraints: Constraint settings (fixed atoms/cell/bonds)

--- a/src/mcp_atomictoolkit/workflows/core.py
+++ b/src/mcp_atomictoolkit/workflows/core.py
@@ -10,6 +10,7 @@ from ase import Atoms
 from mcp_atomictoolkit.analysis.autocorrelation import analyze_vacf
 from mcp_atomictoolkit.analysis.structure import analyze_structure
 from mcp_atomictoolkit.analysis.trajectory import analyze_trajectory
+from mcp_atomictoolkit.calculators import DEFAULT_CALCULATOR_NAME
 from mcp_atomictoolkit.io_handlers import read_structure, write_structure
 from mcp_atomictoolkit.md_runner import run_md
 from mcp_atomictoolkit.optimizers import optimize_structure
@@ -109,7 +110,7 @@ def optimize_structure_workflow(
     input_format: Optional[str] = None,
     output_filepath: str = "optimized.extxyz",
     output_format: Optional[str] = None,
-    calculator_name: str = "nequix",
+    calculator_name: str = DEFAULT_CALCULATOR_NAME,
     max_steps: int = 50,
     fmax: float = 0.1,
     constraints: Optional[Dict] = None,
@@ -142,7 +143,7 @@ def run_md_workflow(
     output_format: Optional[str] = None,
     log_filepath: str = "md.log",
     summary_filepath: str = "md_summary.txt",
-    calculator_name: str = "nequix",
+    calculator_name: str = DEFAULT_CALCULATOR_NAME,
     integrator: str = "velocityverlet",
     timestep_fs: float = 1.0,
     temperature_K: float = 300.0,


### PR DESCRIPTION
### Motivation
- Prefer the KIM backend by default for MD/optimization workflows while preserving existing explicit overrides and configuration paths. 
- Accept common aliases (including the LLM-style phrase `orb of nequix`) so callers or LLMs can request Orb when it is judged superior.

### Description
- Added `DEFAULT_CALCULATOR_NAME = "kim"` and an explanatory comment to `src/mcp_atomictoolkit/calculators.py` to centralize the default calculator. 
- Normalized calculator names in `_normalize_calculator_name` (strip/lower) and added aliases for `"orb of nequix"`, `"orb-of-nequix"`, and the `"neqix"` typo. 
- Switched default `calculator_name` parameters to `DEFAULT_CALCULATOR_NAME` in `src/mcp_atomictoolkit/workflows/core.py`, `src/mcp_atomictoolkit/md_runner.py`, `src/mcp_atomictoolkit/optimizers.py`, and `src/mcp_atomictoolkit/mcp_server.py` and updated docstrings to document the KIM default. 
- Preserved the existing `get_calculator` dispatch and species handling so explicit overrides and configuration/alias pathways continue to work unchanged. 

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698697819e1c832e820ae261a3f43bc9)