### PR TITLE
Add integration test for ASE KIM Si model selection

### DIFF
--- a/tests/test_kim_integration.py
+++ b/tests/test_kim_integration.py
@@ -1,0 +1,43 @@
+import pytest
+from ase import Atoms
+
+from mcp_atomictoolkit import calculators
+
+
+def test_ase_kim_uses_first_model_for_si():
+    kim_query = pytest.importorskip("kim_query")
+    pytest.importorskip("ase.calculators.kim.kim")
+
+    try:
+        models = kim_query.get_available_models(species=["Si"], potential_type=["any"])
+    except Exception as exc:
+        pytest.skip(f"OpenKIM query failed: {exc}")
+    if not models:
+        pytest.skip("OpenKIM query returned no models for Si.")
+
+    def _coerce_model_id(entry):
+        if isinstance(entry, str):
+            return entry
+        if isinstance(entry, dict):
+            for key in ("model", "model_id", "kim_id", "extended_id", "id"):
+                value = entry.get(key)
+                if value:
+                    return value
+        return str(entry)
+
+    first_model_id = _coerce_model_id(models[0])
+    model_id = calculators._select_kim_model_id(["Si"])
+    if model_id == calculators.KIM_DEFAULT_MODEL:
+        pytest.skip("No OpenKIM models discovered for Si.")
+    assert model_id == first_model_id
+
+    calc = calculators.get_kim_calculator(species=["Si"])
+    atoms = Atoms("Si2", positions=[[0, 0, 0], [2.35, 0, 0]], cell=[10, 10, 10], pbc=True)
+    atoms.calc = calc
+
+    try:
+        energy = atoms.get_potential_energy()
+    except Exception as exc:
+        pytest.skip(f"ASE KIM model could not compute energy: {exc}")
+
+    assert energy is not None


### PR DESCRIPTION
### Motivation
- Verify that the KIM integration selects the first OpenKIM model for a queried species and that ASE can use that model to compute a simple potential energy for Si.
- Provide a robust test that skips cleanly when network access, OpenKIM models, or the ASE/KIM runtime are unavailable.

### Description
- Add `tests/test_kim_integration.py` which queries `kim_query.get_available_models` for `Si` and coerces the first model id from either string or dict entries.
- Assert that `calculators._select_kim_model_id(['Si'])` returns the same first-model id and then initialize a KIM calculator via `calculators.get_kim_calculator`.
- Build a small ASE `Atoms` object (`Si2`) and attempt `atoms.get_potential_energy()` to validate the end-to-end ASE+KIM energy evaluation.
- Implement graceful skipping for missing imports, OpenKIM query errors, empty model lists, and KIM/ASE runtime failures.

### Testing
- Ran `pytest tests/test_kim_integration.py` which initially errored during collection with `ModuleNotFoundError: ase` due to missing dependency.
- Installed `ase` and `kim-query` with `pip` and re-ran the test which failed due to a network/proxy `ProxyError` when querying OpenKIM.
- Updated the test to catch query exceptions and re-ran `pytest tests/test_kim_integration.py`, which reported `1 skipped` because OpenKIM or the local KIM runtime was unavailable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986c57d45cc832eab8dc21c4873611c)