### PR TITLE
Fix bicrystal stacking axis handling

### DIFF
--- a/src/mcp_atomictoolkit/structure_operations.py
+++ b/src/mcp_atomictoolkit/structure_operations.py
@@ -69,13 +69,17 @@ def _stack_grains(
     gap: float,
     pbc: Sequence[bool],
 ) -> Atoms:
-    translation = np.zeros(3)
-    translation[axis] = grain_a.cell.lengths()[axis] + gap
+    axis_vector = grain_a.cell.array[axis]
+    axis_length = np.linalg.norm(axis_vector)
+    if axis_length == 0:
+        raise ValueError("Grain cell axis length must be non-zero")
+    axis_unit = axis_vector / axis_length
+    translation = axis_vector + axis_unit * gap
     grain_b = grain_b.copy()
     grain_b.translate(translation)
     combined = grain_a + grain_b
     cell = grain_a.cell.array.copy()
-    cell[axis] = cell[axis] + grain_b.cell.array[axis] + translation[axis]
+    cell[axis] = cell[axis] + grain_b.cell.array[axis] + axis_unit * gap
     combined.set_cell(cell)
     combined.pbc = pbc
     return combined


### PR DESCRIPTION
### Motivation
- Address incorrect translation and cell adjustment when stacking bicrystal grains so grains are separated along the actual cell axis vector instead of a scalar index-based offset.
- Prevent silent failures or invalid geometry when a cell axis has zero length by adding an explicit guard.

### Description
- Update `_stack_grains` in `src/mcp_atomictoolkit/structure_operations.py` to compute the axis vector via `grain_a.cell.array[axis]` and its unit vector with `np.linalg.norm`, and use that to build the translation vector instead of writing into a single-axis scalar index.
- Add a zero-length check that raises `ValueError` when the selected grain cell axis length is zero.
- Adjust the combined cell update to add the other grain cell vector and the gap along the axis unit vector instead of relying on scalar `translation[axis]` indexing.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986e90c5734832e88693d4a40913695)