### PR TITLE
Add 'auto' MLIP selection with fallbacks and report calculator usage

### DIFF
--- a/src/mcp_atomictoolkit/mcp_server.py
+++ b/src/mcp_atomictoolkit/mcp_server.py
@@ -52,6 +52,10 @@ def _error_hints(tool_name: str, kwargs: Dict[str, Any], exc: Exception) -> List
         hints.append("Verify file paths are correct and that prior workflow steps completed successfully.")
     if tool_name in {"optimize_structure_workflow", "run_md_workflow", "analyze_trajectory_workflow"}:
         hints.append("Use returned artifact download_url links for trajectory/log/analysis files instead of regenerating files manually.")
+    if "kimpy" in msg or "kim api" in msg or "openkim" in msg:
+        hints.append(
+            "KIM dependencies are missing. Either install kimpy/KIM API on the server or set calculator_name to 'auto', 'orb', or 'nequix' to use an available backend."
+        )
 
     return hints
 
@@ -228,7 +232,7 @@ async def optimize_structure_workflow(
         input_format: File format (optional)
         output_filepath: Output file path
         output_format: Output file format (optional)
-        calculator_name: Type of MLIP ('kim', 'nequix', or 'orb'). Defaults to KIM.
+        calculator_name: Type of MLIP ('auto', 'kim', 'nequix', or 'orb'). Defaults to auto.
         max_steps: Maximum optimization steps
         fmax: Force convergence criterion
         constraints: Constraint settings (fixed atoms/cell/bonds)

--- a/src/mcp_atomictoolkit/workflows/core.py
+++ b/src/mcp_atomictoolkit/workflows/core.py
@@ -133,6 +133,9 @@ def optimize_structure_workflow(
         "converged": optimized.info.get("optimization_converged", False),
         "steps": optimized.info.get("optimization_steps", 0),
         "final_fmax": optimized.info.get("optimization_fmax", None),
+        "calculator_requested": optimized.info.get("calculator_requested", calculator_name),
+        "calculator_used": optimized.info.get("calculator_used", calculator_name),
+        "calculator_fallbacks": optimized.info.get("calculator_fallbacks", []),
     }
 
 


### PR DESCRIPTION
### Motivation
- The server can fail on low-resource hosts when heavyweight KIM dependencies (`kimpy`/KIM API) are missing, causing workflows to error instead of using alternate backends.
- Provide better diagnostics so callers can see which MLIP was requested, which backend was actually used, and any fallback errors.

### Description
- Change default `DEFAULT_CALCULATOR_NAME` from `"kim"` to `"auto"` and add alias support for `"auto-select"`/`"auto_select"` so environments can request auto-selection.
- Add `resolve_calculator` and `_get_calculator_by_key` which try candidates (`"kim"`, `"orb"`, `"nequix"`) in order and return the chosen calculator plus used key and any fallback errors, and update `get_calculator` to call the resolver.
- Update `optimize_structure` and `run_md` to use `resolve_calculator`, attach `calculator_requested`, `calculator_used`, and `calculator_fallbacks` to `atoms.info`, and include these fields in workflow responses from `optimize_structure_workflow` and `run_md_workflow`.
- Improve error hints in `_error_hints` to add a clear suggestion when KIM/KIMPY dependencies are missing and recommend using `'auto'`, `'orb'`, or `'nequix'` as a workaround.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698794ebb7e0832e8f9a4f347218d8b6)