### PR TITLE
Expose single-point workflow, surface optimizer/MD options, and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Main MCP tools exposed by the server:
 - `analyze_structure_workflow`
 - `write_structure_workflow`
 - `optimize_structure_workflow`
+- `single_point_workflow`
 - `run_md_workflow`
 - `analyze_trajectory_workflow`
 - `autocorrelation_workflow`
@@ -142,6 +143,62 @@ src/mcp_atomictoolkit/
   md_runner.py
   artifact_store.py      # Download artifact registration + URLs
 ```
+
+---
+
+## 🧪 Workflow Notes (for MCP clients)
+
+### Structure building coverage
+
+`build_structure_workflow` supports:
+
+- **bulk** (ASE `bulk`)
+- **surface** (ASE `surface`)
+- **molecule** (ASE `molecule`)
+- **supercell** (multiplication of a base structure)
+- **amorphous/liquid** (random packed structures)
+- **bicrystal** and **polycrystal** (grain stacking/rotation)
+
+For **interfaces, doped structures, adsorbates, or custom slabs**, prefer:
+
+1. Generate the structure with ASE/pymatgen (or an external builder), then
+2. Use `write_structure_workflow` to persist the final geometry for downstream steps.
+
+This ensures MCP callers can still handle advanced structures even when a specialized
+builder is required.
+
+### Builder kwargs cheat sheet
+
+Common `builder_kwargs` for `build_structure_workflow`:
+
+- **surface**: `indices`, `layers`, `vacuum`
+- **supercell**: `size`, `base_structure_type`, `base_crystal_system`, `base_lattice_constant`, `base_kwargs`
+- **amorphous/liquid**: `num_atoms`, `box_length`, `relax`, `relax_steps`, `relax_fmax`
+- **bicrystal**: `grain_size`, `interface_axis`, `rotation_angle`, `rotation_axis`, `interface_gap`
+- **polycrystal**: `num_grains`, `grain_size`, `rotation_angle`
+
+### Optimization options
+
+`optimize_structure_workflow` exposes:
+
+- `max_steps`, `fmax` (convergence)
+- `maxstep`, `alpha` (BFGS step/damping controls)
+- `constraints` (`fixed_atoms`, `fixed_bonds`, `fixed_cell`)
+
+### Single-point calculations
+
+`single_point_workflow` computes **energy**, **forces**, and **stress** (if periodic)
+without modifying the structure, making it suitable for quick evaluations.
+
+### MD integrators / ensembles
+
+`run_md_workflow` supports:
+
+- `velocityverlet` / `nve` (NVE)
+- `langevin` / `nvt-langevin` (NVT)
+- `nvt` / `nvt-berendsen` (NVT)
+
+Tune `temperature_K`, `friction`, and `taut` to control thermostat behavior.
 
 ---
 

--- a/src/mcp_atomictoolkit/workflows/__init__.py
+++ b/src/mcp_atomictoolkit/workflows/__init__.py
@@ -7,6 +7,7 @@ from .core import (
     build_structure_workflow,
     optimize_structure_workflow,
     run_md_workflow,
+    single_point_workflow,
     write_structure_workflow,
 )
 
@@ -17,5 +18,6 @@ __all__ = [
     "build_structure_workflow",
     "optimize_structure_workflow",
     "run_md_workflow",
+    "single_point_workflow",
     "write_structure_workflow",
 ]

--- a/tests/test_mcp_server_utils.py
+++ b/tests/test_mcp_server_utils.py
@@ -35,6 +35,7 @@ def _load_mcp_server(monkeypatch):
         "build_structure_workflow",
         "optimize_structure_workflow",
         "run_md_workflow",
+        "single_point_workflow",
         "write_structure_workflow",
     ):
         setattr(


### PR DESCRIPTION
### Motivation

- Provide an MCP-accessible single-point evaluation so callers can obtain energy/forces/stress without running optimization or MD. 
- Surface additional optimizer controls to make geometry optimization robust for varied workloads (e.g., BFGS tuning). 
- Clarify builder, optimization, and MD options in the README so LLM-driven clients and downstream tools can reliably construct and run workflows.

### Description

- Add `single_point_workflow` to `src/mcp_atomictoolkit/workflows/core.py` which reads a structure, resolves a calculator via `resolve_calculator`, and returns `energy`, `forces`, `stress`, and calculator metadata. 
- Expose `single_point_workflow` as an MCP tool in `src/mcp_atomictoolkit/mcp_server.py` and register it in `workflows/__init__.py` for package exports. 
- Add optimizer tuning parameters `maxstep` and `alpha` to `optimize_structure_workflow` (both server-facing and workflow orchestration layers) and forward them into the optimizer call. 
- Document structure-building coverage, `builder_kwargs` cheat sheet, optimization knobs, single-point behavior, and supported MD integrators/ensembles in `README.md` to help MCP clients (and LLM agents) use the toolkit correctly.

### Testing

- No automated tests were executed as part of this change; please run the repository test suite (e.g., `pytest` / CI) to validate runtime behavior and integration with MLIP backends.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988d675e828832eaf431f028f507ca5)