### PR TITLE
Add fast root GET/HEAD response and enforce CPU-only JAX plugin skips

### DIFF
--- a/src/mcp_atomictoolkit/calculators.py
+++ b/src/mcp_atomictoolkit/calculators.py
@@ -24,6 +24,9 @@ def _configure_jax_for_cpu() -> None:
     """Force JAX/Nequix execution on CPU-only runtimes."""
     # We intentionally overwrite these values to guarantee CPU execution even
     # when a hosting environment pre-sets GPU defaults.
+    os.environ["JAX_PLUGINS"] = ""
+    os.environ["JAX_SKIP_JAXLIB_PJRT_CUDA_PLUGIN"] = "1"
+    os.environ["JAX_SKIP_JAXLIB_PJRT_ROCM_PLUGIN"] = "1"
     os.environ["JAX_PLATFORMS"] = "cpu"
     os.environ["JAX_PLATFORM_NAME"] = "cpu"
     os.environ["CUDA_VISIBLE_DEVICES"] = ""

--- a/src/mcp_atomictoolkit/http_app.py
+++ b/src/mcp_atomictoolkit/http_app.py
@@ -94,14 +94,39 @@ class _AcceptHeaderCompatApp:
         await self.app(scope, receive, send)
 
 
+class _RootInfoApp:
+    """ASGI adapter that serves a fast GET/HEAD response on the MCP root."""
+
+    def __init__(self, app) -> None:
+        self.app = app
+        self.lifespan = getattr(app, "lifespan", None)
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope.get("type") == "http" and scope.get("path") == "/":
+            method = scope.get("method", "GET").upper()
+            if method in {"GET", "HEAD"}:
+                response = JSONResponse(
+                    {
+                        "status": "ok",
+                        "service": "atomictoolkit",
+                        "mcp": "streamable-http",
+                    }
+                )
+                await response(scope, receive, send)
+                return
+        await self.app(scope, receive, send)
+
+
 # Primary MCP endpoint expected by Smithery and most registries.
 _mcp_root_app = _ArtifactBaseUrlContextApp(
     _AcceptHeaderCompatApp(
-        mcp.http_app(
-            path="/",
-            transport="streamable-http",
-            json_response=True,
-            stateless_http=True,
+        _RootInfoApp(
+            mcp.http_app(
+                path="/",
+                transport="streamable-http",
+                json_response=True,
+                stateless_http=True,
+            )
         )
     )
 )


### PR DESCRIPTION
### Motivation
- Prevent JAX/Nequix from attempting CUDA/ROCm plugin discovery on CPU-only hosts by forcing a CPU-only JAX environment to avoid initialization errors (e.g., `cuInit(0) failed`).
- Keep the MCP root responsive to scanners and health checks (e.g., Smithery) by returning a fast GET/HEAD response at `/` while preserving full MCP POST handling for JSON-RPC traffic.

### Description
- In `src/mcp_atomictoolkit/calculators.py` updated `_configure_jax_for_cpu()` to set `JAX_PLUGINS = ""` and add `JAX_SKIP_JAXLIB_PJRT_CUDA_PLUGIN="1"` and `JAX_SKIP_JAXLIB_PJRT_ROCM_PLUGIN="1"` in addition to the existing CPU-only env vars so JAX imports run in CPU-only mode.
- In `src/mcp_atomictoolkit/http_app.py` added a new ASGI adapter `_RootInfoApp` that returns a fast `JSONResponse` for `GET`/`HEAD` requests on path `/` and wired it into the existing middleware stack so scanners receive a quick connectivity response while `mcp.http_app` continues to handle POST/streamable HTTP requests.
- Maintained the existing `_AcceptHeaderCompatApp` and `_ArtifactBaseUrlContextApp` wrappers and ensured the new adapter is applied without breaking MCP POST handling.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69890e491f74832ea1f1cd025417fe93)