### PR TITLE
Force JAX CPU settings in MCP server

### DIFF
--- a/src/mcp_atomictoolkit/mcp_server.py
+++ b/src/mcp_atomictoolkit/mcp_server.py
@@ -7,6 +7,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from time import perf_counter
 from typing import Any, Callable, Dict, List, Optional
+os.environ["JAX_PLUGINS"] = ""
+os.environ["JAX_SKIP_JAXLIB_PJRT_CUDA_PLUGIN"] = "1"
+os.environ["JAX_SKIP_JAXLIB_PJRT_ROCM_PLUGIN"] = "1"
+os.environ["JAX_PLATFORMS"] = "cpu"
+os.environ["JAX_PLATFORM_NAME"] = "cpu"
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
+os.environ["JAX_CUDA_VISIBLE_DEVICES"] = ""
+
 from fastmcp import FastMCP
 
 from mcp_atomictoolkit.artifact_store import with_downloadable_artifacts


### PR DESCRIPTION
### Motivation
- Prevent JAX from attempting to initialize CUDA (which causes errors like `cuInit(0) failed`) by ensuring the MCP server runs with CPU-only JAX configuration at import time.

### Description
- Set CPU-only environment flags at the top of `src/mcp_atomictoolkit/mcp_server.py` by assigning `JAX_PLUGINS`, `JAX_SKIP_JAXLIB_PJRT_CUDA_PLUGIN`, `JAX_SKIP_JAXLIB_PJRT_ROCM_PLUGIN`, `JAX_PLATFORMS`, `JAX_PLATFORM_NAME`, `CUDA_VISIBLE_DEVICES`, and `JAX_CUDA_VISIBLE_DEVICES` to force JAX/Nequix to use the CPU and avoid CUDA plugin initialization.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69894f059f60832eb9482edce69d2524)