### PR TITLE
Add KIM model fallback when selected model unavailable

### DIFF
--- a/src/mcp_atomictoolkit/calculators.py
+++ b/src/mcp_atomictoolkit/calculators.py
@@ -154,6 +154,23 @@ def get_kim_calculator(
     try:
         return KIM(model_id)
     except Exception as exc:
+        if model_id != KIM_DEFAULT_MODEL:
+            warnings.warn(
+                (
+                    f"KIM model '{model_id}' is unavailable; falling back to "
+                    f"default model '{KIM_DEFAULT_MODEL}'. Original error: {exc}"
+                ),
+                RuntimeWarning,
+            )
+            try:
+                return KIM(KIM_DEFAULT_MODEL)
+            except Exception as fallback_exc:
+                message = (
+                    f"Failed to initialize KIM model '{model_id}' and fallback model "
+                    f"'{KIM_DEFAULT_MODEL}'. Ensure the KIM API and kimpy are installed "
+                    "and that the models are available locally."
+                )
+                raise RuntimeError(message) from fallback_exc
         message = (
             f"Failed to initialize KIM model '{model_id}'. Ensure the KIM API and kimpy "
             "are installed and that the model is available locally."


### PR DESCRIPTION
### Motivation
- Initializing a requested OpenKIM model can fail when the model is not installed locally, causing `get_kim_calculator` to raise and break higher-level workflows.
- Provide a graceful fallback to the packaged default KIM model to improve robustness in environments where specific KIM models are missing.
- Surface a clear warning so users know the requested model was unavailable and a fallback was used.

### Description
- Update `get_kim_calculator` to catch initialization errors and, when the selected model differs from `KIM_DEFAULT_MODEL`, emit a `RuntimeWarning` and retry initialization with `KIM_DEFAULT_MODEL` before raising a final error.
- Preserve the original error semantics when the selected model equals the default or when both the requested and fallback models fail to initialize.
- Add `test_get_kim_calculator_falls_back_to_default_model` to `tests/test_calculators_factory.py` to exercise the fallback and the emitted warning.

### Testing
- Added a unit test `test_get_kim_calculator_falls_back_to_default_model` that stubs the ASE KIM `KIM` class and `kim_query` to verify the fallback path.
- Ran `pytest -q` locally, but test collection was interrupted due to missing optional dependencies (`numpy`, `ase`, `fastmcp`, `hypothesis`) in the environment, so the full test suite did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a1cfa3e78832e838b1771682071fa)